### PR TITLE
feat: debounce time to order button

### DIFF
--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -19,7 +19,13 @@
       >
         <div class="header-style">
           <span class="th-span">{{ column.label }}</span>
-          <button class="svg" (click)="sort(column)" *ngIf="column.sort">
+          <button
+            class="svg"
+            (click)="
+              !!config.debounceOnSort ? sortWithDebounce(column) : sort(column)
+            "
+            *ngIf="column.sort"
+          >
             <svg
               [attr.data-testid]="'sort-by-' + column.key"
               width="8"

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -545,6 +545,7 @@ describe('Table > Pagination', () => {
     const withoutConfigItemsPerPage = JSON.parse(
       JSON.stringify(defaultProps)
     ) as IonSmartTableProps<Character>;
+    withoutConfigItemsPerPage.events = { emit: jest.fn() } as SafeAny;
     withoutConfigItemsPerPage.config.pagination = {
       total: 32,
       page: 1,
@@ -570,6 +571,7 @@ describe('Table > Action with confirm', () => {
     const withPopconfirm = JSON.parse(
       JSON.stringify(defaultProps)
     ) as IonSmartTableProps<Character>;
+    withPopconfirm.events = { emit: jest.fn() } as SafeAny;
 
     const actionConfig = {
       label: 'Excluir',
@@ -594,6 +596,7 @@ describe('Table > Action with confirm', () => {
     const withPopconfirm = JSON.parse(
       JSON.stringify(defaultProps)
     ) as IonSmartTableProps<Character>;
+    withPopconfirm.events = { emit: jest.fn() } as SafeAny;
 
     const actionConfig = {
       label: 'Excluir',

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -533,10 +533,34 @@ describe('Table > Differents columns data type', () => {
       expect(arrowUp).toHaveAttribute('fill', disabledArrowColor);
       expect(arrowDown).toHaveAttribute('fill', disabledArrowColor);
     });
+
+    it('should only emit sort action after a given debounce time', async () => {
+      jest.useFakeTimers();
+
+      tableDifferentColumns.config.columns = [
+        {
+          label: 'Albuns',
+          sort: true,
+          key: 'albuns',
+        },
+      ];
+      tableDifferentColumns.config.debounceOnSort = 2000;
+
+      await sut(tableDifferentColumns);
+      eventSelect.mockClear();
+      fireEvent.click(screen.getByTestId('sort-by-albuns'));
+
+      expect(tableDifferentColumns.events.emit).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(2000);
+
+      expect(tableDifferentColumns.events.emit).toHaveBeenCalled();
+    });
   });
 
   afterAll(() => {
     eventSelect.mockClear();
+    jest.useRealTimers();
   });
 });
 

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -535,6 +535,7 @@ describe('Table > Differents columns data type', () => {
     });
 
     it('should only emit sort action after a given debounce time', async () => {
+      const debounceTime = 2000;
       jest.useFakeTimers();
 
       tableDifferentColumns.config.columns = [
@@ -544,16 +545,14 @@ describe('Table > Differents columns data type', () => {
           key: 'albuns',
         },
       ];
-      tableDifferentColumns.config.debounceOnSort = 2000;
+      tableDifferentColumns.config.debounceOnSort = debounceTime;
 
       await sut(tableDifferentColumns);
       eventSelect.mockClear();
       fireEvent.click(screen.getByTestId('sort-by-albuns'));
-
       expect(tableDifferentColumns.events.emit).not.toHaveBeenCalled();
 
-      jest.advanceTimersByTime(2000);
-
+      jest.advanceTimersByTime(debounceTime);
       expect(tableDifferentColumns.events.emit).toHaveBeenCalled();
     });
   });

--- a/projects/ion/src/lib/smart-table/smart-table.component.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.ts
@@ -12,6 +12,7 @@ import {
   TableUtils,
 } from '../table/utilsTable';
 import { SafeAny } from '../utils/safe-any';
+import debounce from '../utils/debounce';
 
 const stateChange = {
   checked: 'enabled',
@@ -25,6 +26,7 @@ export interface IonSmartTableProps<T> {
 
 export interface ConfigSmartTable<T> extends ConfigTable<T> {
   pagination: PaginationConfig;
+  debounceOnSort?: number;
 }
 
 @Component({
@@ -38,6 +40,7 @@ export class IonSmartTableComponent implements OnInit {
 
   public mainCheckBoxState: CheckBoxStates = 'enabled';
   public pagination!: PageEvent;
+  public sortWithDebounce: (column: Column) => void;
 
   private firstLoad = true;
   private tableUtils: TableUtils;
@@ -46,6 +49,11 @@ export class IonSmartTableComponent implements OnInit {
     this.tableUtils = new TableUtils(this.config);
     if (!this.config.pagination.itemsPerPage) {
       this.config.pagination.itemsPerPage = ITEMS_PER_PAGE_DEFAULT;
+    }
+    if (this.config.debounceOnSort) {
+      this.sortWithDebounce = debounce((column: Column) => {
+        this.sort(column);
+      }, this.config.debounceOnSort);
     }
   }
 

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -82,7 +82,8 @@ function returnTableConfig(
   tableData,
   tableColumns,
   tableActions,
-  paginationTotal
+  paginationTotal,
+  debounceOnSort = 0
 ): SafeAny {
   return {
     config: {
@@ -93,6 +94,7 @@ function returnTableConfig(
       pagination: {
         total: paginationTotal,
       },
+      debounceOnSort,
     },
   };
 }
@@ -105,3 +107,6 @@ NoData.args = returnTableConfig([], columns, actions, 0);
 
 export const SelectableCells = Template.bind({});
 SelectableCells.args = returnTableConfig(data, selectableColumns, actions, 2);
+
+export const SortWithDebounce = Template.bind({});
+SortWithDebounce.args = returnTableConfig(data, columns, actions, 2, 2000);


### PR DESCRIPTION
- Add a debounce time that can be given on smart table config, that will only emit one sort event after a given time, independent of how many times the user clicked on sort button;
- Fix console errors when smart table tests were run.