### PR TITLE
fix: fix indicator alignment

### DIFF
--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -15,7 +15,7 @@
     >
     </ion-icon>
   </header>
-  <div class="content" [class.with-footer]="buttonConfig">
+  <div class="content with-footer">
     <header>
       <h4 data-testid="ion-indicator-value">{{ value }}</h4>
       <p data-testid="ion-indicator-second-value">{{ secondValue }}</p>


### PR DESCRIPTION
Indicator now considers the space of the footer, even if there is no action.

![image](https://user-images.githubusercontent.com/57760325/220642018-17caeaeb-b498-46ac-81e2-aeaed4263a30.png)
