### PR TITLE
353 fix sorting when paginating the table

### DIFF
--- a/projects/ion/src/lib/table/table.component.spec.ts
+++ b/projects/ion/src/lib/table/table.component.spec.ts
@@ -519,6 +519,16 @@ describe('Table > Pagination', () => {
     expect(screen.getByTestId('page-7')).toBeInTheDocument();
     expect(screen.queryAllByTestId('page-8')).toHaveLength(0);
   });
+
+  it('should return to page 1 when sort is activated on a column', async () => {
+    await sut(tableWithPagination);
+
+    fireEvent.click(screen.getByTestId('page-2'));
+    expect(screen.getByTestId('page-2')).toHaveClass('selected');
+
+    fireEvent.click(screen.getByTestId('sort-by-name'));
+    expect(screen.getByTestId('page-1')).toHaveClass('selected');
+  });
 });
 
 describe('Table > Action with confirm', () => {

--- a/projects/ion/src/lib/table/table.component.spec.ts
+++ b/projects/ion/src/lib/table/table.component.spec.ts
@@ -520,7 +520,15 @@ describe('Table > Pagination', () => {
     expect(screen.queryAllByTestId('page-8')).toHaveLength(0);
   });
 
-  it('should return to page 1 when sort is activated on a column', async () => {
+  it('should render a page selected when its passed on configuration', async () => {
+    const customInitialPage = { ...tableWithPagination };
+    customInitialPage.config.pagination.page = 3;
+    await sut(customInitialPage);
+    expect(screen.getByTestId('page-3')).toBeInTheDocument();
+    expect(screen.getByTestId('page-3')).toHaveClass('selected');
+  });
+
+  it('should return to first page when sort is activated on a column', async () => {
     await sut(tableWithPagination);
 
     fireEvent.click(screen.getByTestId('page-2'));

--- a/projects/ion/src/lib/table/table.component.ts
+++ b/projects/ion/src/lib/table/table.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ChangeDetectorRef,
+} from '@angular/core';
 import { CheckBoxStates } from '../core/types/checkbox';
 import { PageEvent } from '../core/types/pagination';
 import { TableEvent } from '../core/types/table';
@@ -19,6 +26,8 @@ export class IonTableComponent implements OnInit {
   @Input() config: ConfigTable<SafeAny>;
   @Output() events = new EventEmitter<TableEvent>();
 
+  constructor(private cdr: ChangeDetectorRef) {}
+
   public mainCheckBoxState: CheckBoxStates = 'enabled';
   public smartData = [];
   private tableUtils: TableUtils;
@@ -33,10 +42,12 @@ export class IonTableComponent implements OnInit {
 
       this.config.pagination.page = this.config.pagination.page || 1;
 
-      this.smartData = this.config.data.slice(
-        this.config.pagination.offset,
-        this.config.pagination.itemsPerPage
-      );
+      this.paginationEvents({
+        actual: this.config.pagination.page,
+        itemsPerPage: this.config.pagination.itemsPerPage,
+        offset: this.config.pagination.offset * this.config.pagination.page,
+      });
+
       return;
     }
     this.smartData = this.config.data;
@@ -91,11 +102,11 @@ export class IonTableComponent implements OnInit {
     column.desc = !column.desc;
 
     if (this.config.pagination) {
-      this.smartData = this.config.data.slice(
-        this.config.pagination.offset,
-        this.config.pagination.itemsPerPage
-      );
-      this.config.pagination.page = 1;
+      this.paginationEvents({
+        actual: 1,
+        itemsPerPage: this.config.pagination.itemsPerPage,
+        offset: this.config.pagination.offset,
+      });
     }
   }
 
@@ -115,6 +126,8 @@ export class IonTableComponent implements OnInit {
       event.offset + event.itemsPerPage
     );
     this.config.pagination.page = event.actual;
+
+    this.cdr.detectChanges();
   }
 
   private setMainCheckboxState(state: CheckBoxStates): void {

--- a/projects/ion/src/lib/table/table.component.ts
+++ b/projects/ion/src/lib/table/table.component.ts
@@ -31,6 +31,8 @@ export class IonTableComponent implements OnInit {
       this.config.pagination.itemsPerPage =
         this.config.pagination.itemsPerPage || defaultItemsPerPage;
 
+      this.config.pagination.page = this.config.pagination.page || 1;
+
       this.smartData = this.config.data.slice(
         this.config.pagination.offset,
         this.config.pagination.itemsPerPage
@@ -87,6 +89,14 @@ export class IonTableComponent implements OnInit {
       }
     });
     column.desc = !column.desc;
+
+    if (this.config.pagination) {
+      this.smartData = this.config.data.slice(
+        this.config.pagination.offset,
+        this.config.pagination.itemsPerPage
+      );
+      this.config.pagination.page = 1;
+    }
   }
 
   public handleEvent(row: SafeAny, action: ActionTable): void {
@@ -104,6 +114,7 @@ export class IonTableComponent implements OnInit {
       event.offset,
       event.offset + event.itemsPerPage
     );
+    this.config.pagination.page = event.actual;
   }
 
   private setMainCheckboxState(state: CheckBoxStates): void {


### PR DESCRIPTION
**- Fixed a bug when, on a paginated table, sorting was not taking any effect (more details on #353).**

[Screencast from 28-02-2023 17:05:30.webm](https://user-images.githubusercontent.com/57760325/221967100-1d6d9d93-04a9-4f31-ab9c-0cce8d81a23d.webm)
##
**- Fixed a bug when passing a initial page on a pagination config doesn't make any difference when table was rendered, always starting on page 1.**