### PR TITLE
🚚 fix: smart-table interfaces exports

### DIFF
--- a/projects/ion/src/lib/core/types/smart-table.ts
+++ b/projects/ion/src/lib/core/types/smart-table.ts
@@ -1,6 +1,11 @@
-import { EventTable } from '../../table/utilsTable';
+import {
+  EventTable,
+  PaginationConfig,
+  ConfigTable,
+} from '../../table/utilsTable';
 import { SafeAny } from '../../utils/safe-any';
 import { PageEvent } from './pagination';
+import { EventEmitter } from '@angular/core';
 
 export interface SmartTableEvent {
   event: EventTable;
@@ -11,4 +16,14 @@ export interface SmartTableEvent {
     desc: boolean;
   };
   data?: SafeAny;
+}
+
+export interface IonSmartTableProps<T> {
+  config: ConfigSmartTable<T>;
+  events?: EventEmitter<SmartTableEvent>;
+}
+
+export interface ConfigSmartTable<T> extends ConfigTable<T> {
+  pagination: PaginationConfig;
+  debounceOnSort?: number;
 }

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -1,9 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { SafeAny } from '../utils/safe-any';
-import {
-  IonSmartTableProps,
-  IonSmartTableComponent,
-} from './smart-table.component';
+import { IonSmartTableComponent } from './smart-table.component';
 import { ActionTable, Column, EventTable } from '../table/utilsTable';
 import { IonCheckboxModule } from '../checkbox/checkbox.module';
 import { IonPaginationModule } from '../pagination/pagination.module';
@@ -11,6 +8,7 @@ import { IonTagModule } from '../tag/tag.module';
 import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
 import { IonButtonModule } from '../button/button.module';
 import { IonIconModule } from '../icon/icon.module';
+import { IonSmartTableProps } from '../core/types';
 
 const disabledArrowColor = '#CED2DB';
 const enabledArrowColor = '#0858CE';

--- a/projects/ion/src/lib/smart-table/smart-table.component.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.ts
@@ -1,14 +1,12 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { SmartTableEvent } from '../core/types';
+import { SmartTableEvent, ConfigSmartTable } from '../core/types';
 import { CheckBoxStates } from '../core/types/checkbox';
 import { PageEvent } from '../core/types/pagination';
 import { ITEMS_PER_PAGE_DEFAULT } from '../pagination/pagination.component';
 import {
   ActionTable,
   Column,
-  ConfigTable,
   EventTable,
-  PaginationConfig,
   TableUtils,
 } from '../table/utilsTable';
 import { SafeAny } from '../utils/safe-any';
@@ -18,16 +16,6 @@ const stateChange = {
   checked: 'enabled',
   enabled: 'checked',
 };
-
-export interface IonSmartTableProps<T> {
-  config: ConfigSmartTable<T>;
-  events?: EventEmitter<SmartTableEvent>;
-}
-
-export interface ConfigSmartTable<T> extends ConfigTable<T> {
-  pagination: PaginationConfig;
-  debounceOnSort?: number;
-}
 
 @Component({
   selector: 'ion-smart-table',

--- a/projects/ion/src/lib/table/utilsTable.ts
+++ b/projects/ion/src/lib/table/utilsTable.ts
@@ -1,5 +1,5 @@
-import { ConfigSmartTable } from '../smart-table/smart-table.component';
 import { SafeAny } from '../utils/safe-any';
+import { ConfigSmartTable } from '../core/types';
 
 export enum EventTable {
   SORT = 'sort',


### PR DESCRIPTION
Move interfaces from `smart-table.component.ts` to `cores/types/smart-table.ts`.