### PR TITLE
498 hotfix fix tooltip imports

### DIFF
--- a/stories/Tooltip.stories.ts
+++ b/stories/Tooltip.stories.ts
@@ -5,11 +5,9 @@ import {
   TooltipPosition,
   TooltipTrigger,
 } from '../projects/ion/src/lib/core/types';
-import {
-  IonTooltipComponent,
-  TooltipProps,
-} from '../projects/ion/src/lib/tooltip/tooltip.component';
+import { IonTooltipComponent } from '../projects/ion/src/lib/tooltip/tooltip.component';
 import { IonTooltipDirective } from '../projects/ion/src/lib/tooltip/tooltip.directive';
+import { TooltipProps } from '../projects/ion/src/lib/core/types/tooltip';
 
 export default {
   title: 'Ion/Data Display/Tooltip',

--- a/stories/Tooltip.stories.ts
+++ b/stories/Tooltip.stories.ts
@@ -4,10 +4,10 @@ import { Meta, Story } from '@storybook/angular/types-6-0';
 import {
   TooltipPosition,
   TooltipTrigger,
+  TooltipProps,
 } from '../projects/ion/src/lib/core/types';
 import { IonTooltipComponent } from '../projects/ion/src/lib/tooltip/tooltip.component';
 import { IonTooltipDirective } from '../projects/ion/src/lib/tooltip/tooltip.directive';
-import { TooltipProps } from '../projects/ion/src/lib/core/types/tooltip';
 
 export default {
   title: 'Ion/Data Display/Tooltip',


### PR DESCRIPTION
## Description

fix wrong import in tooltipe story

- stories/Tooltip.stories.ts

## Screenshots
before: 
![image](https://user-images.githubusercontent.com/93842972/222422620-ba2e7c0c-160b-445f-9f63-b67244d34393.png)
after:
![image](https://user-images.githubusercontent.com/93842972/222423634-e1d1401c-1906-4266-8608-33c049d15888.png)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
