### PR TITLE
fix: smarttable with columns misaligned when add actions

### DIFF
--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -65,6 +65,7 @@ table {
     &.th-actions {
       color: $neutral-8;
       text-align: left;
+      width: 0%;
     }
 
     & input {


### PR DESCRIPTION
## Description

When I add an action, and some other column has a defined width, the columns that have the width are all at the minimum size, and the action column occupies all the remaining space.

## Expected Behavior

That the ConfigSmartTable can accept a width for the action column.

## Steps to Reproduce

1. Create a smarttable with columns with a width: 1
2. Add an action with the definition of an icon and a label

## Screenshots

![image](https://user-images.githubusercontent.com/15896994/222489718-5757ca61-2ec2-4c2a-9236-a98d34a41c81.png)

## Additional Information

```ts
  public clientTableConfig: ConfigSmartTable<any> = {
    pagination: { total: 1, offset: 0, itemsPerPage: 10, page: 1 },
    data: [],
    columns: [{ key: 'cliente_id', label: 'Código do cliente', width: 1 }],
    actions: [
      {
        icon: 'trash',
        label: 'apagar',
        call(row) {
          console.log({ row });
        },
      },
    ],
  };
```
