### PR TITLE
adding z-index in tooltip(#489)

### DIFF
--- a/projects/ion/src/lib/tooltip/tooltip.component.scss
+++ b/projects/ion/src/lib/tooltip/tooltip.component.scss
@@ -28,6 +28,7 @@ $arrow-size: 4.2px;
 }
 
 .ion-tooltip {
+  z-index: 100;
   position: fixed;
   padding: spacing(1);
   overflow-wrap: break-word;


### PR DESCRIPTION
## Description
I added a z-index with value 100 so that the tooltip can stand out over the modal. I had also created a indicator mock to be able to view the bug.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/81201377/222738588-05ce7158-67d4-4a0a-933f-b4c759066c4f.png)
After adding z-index:
![image](https://user-images.githubusercontent.com/81201377/222738763-fe25377d-1116-4986-a8b2-25d35c5a995f.png)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.