### PR TITLE
✨ feat: template ref on tooltip

### DIFF
--- a/projects/ion/src/lib/tooltip/tooltip.component.html
+++ b/projects/ion/src/lib/tooltip/tooltip.component.html
@@ -10,4 +10,5 @@
   [style.left]="left + 'px'"
 >
   {{ ionTooltipTitle }}
+  <ng-container [ngTemplateOutlet]="ionTooltipTemplateRef"></ng-container>
 </div>

--- a/projects/ion/src/lib/tooltip/tooltip.component.scss
+++ b/projects/ion/src/lib/tooltip/tooltip.component.scss
@@ -32,7 +32,7 @@ $arrow-size: 4.2px;
   position: fixed;
   padding: spacing(1);
   overflow-wrap: break-word;
-  max-width: 188px;
+  max-width: 208px;
   text-align: left;
   font-size: 14px;
   font-weight: 400;

--- a/projects/ion/src/lib/tooltip/tooltip.component.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { TooltipColorScheme, TooltipPosition } from '../core/types';
 
 @Component({
@@ -8,6 +8,7 @@ import { TooltipColorScheme, TooltipPosition } from '../core/types';
 })
 export class IonTooltipComponent {
   ionTooltipTitle: string;
+  ionTooltipTemplateRef: TemplateRef<void>;
   ionTooltipColorScheme: TooltipColorScheme = 'dark';
   ionTooltipPosition: TooltipPosition = TooltipPosition.DEFAULT;
   ionTooltipVisible = false;

--- a/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
@@ -14,6 +14,7 @@ import { IonTooltipModule } from './tooltip.module';
       data-testid="hostTooltip"
       ionTooltip
       [ionTooltipTitle]="ionTooltipTitle"
+      [ionTooltipTemplateRef]="ref"
       [ionTooltipColorScheme]="ionTooltipColorScheme"
       [ionTooltipPosition]="ionTooltipPosition"
       [ionTooltipTrigger]="ionTooltipTrigger"
@@ -21,6 +22,9 @@ import { IonTooltipModule } from './tooltip.module';
     >
       Hover me
     </p>
+    <ng-template #ref>
+      <span data-testid="templateRef">Im a template ref</span>
+    </ng-template>
   `,
 })
 class HostTestComponent {
@@ -68,6 +72,13 @@ describe('Directive: Tooltip', () => {
 
     fireEvent.mouseEnter(screen.getByTestId('hostTooltip'));
     expect(screen.getByText(ionTooltipTitle)).toBeInTheDocument();
+  });
+
+  it('should render tooltip with a template ref', async () => {
+    await sut();
+
+    fireEvent.mouseEnter(screen.getByTestId('hostTooltip'));
+    expect(screen.getByTestId('templateRef')).toBeInTheDocument();
   });
 
   it.each(['light', 'dark'] as TooltipColorScheme[])(

--- a/projects/ion/src/lib/tooltip/tooltip.directive.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.ts
@@ -9,6 +9,7 @@ import {
   Injector,
   Input,
   OnDestroy,
+  TemplateRef,
 } from '@angular/core';
 import {
   TooltipColorScheme,
@@ -24,6 +25,7 @@ import { getPositions } from './utilsTooltip';
 })
 export class IonTooltipDirective implements OnDestroy {
   @Input() ionTooltipTitle = '';
+  @Input() ionTooltipTemplateRef: TemplateRef<void>;
   @Input() ionTooltipColorScheme: TooltipColorScheme = 'dark';
   @Input() ionTooltipPosition: TooltipPosition = TooltipPosition.DEFAULT;
   @Input() ionTooltipArrowPointAtCenter = true;
@@ -65,6 +67,8 @@ export class IonTooltipDirective implements OnDestroy {
   setComponentProperties(): void {
     if (!this.isComponentRefNull()) {
       this.componentRef.instance.ionTooltipTitle = this.ionTooltipTitle;
+      this.componentRef.instance.ionTooltipTemplateRef =
+        this.ionTooltipTemplateRef;
       this.componentRef.instance.ionTooltipColorScheme =
         this.ionTooltipColorScheme;
       this.componentRef.instance.ionTooltipPosition = this.ionTooltipPosition;

--- a/stories/Tooltip.stories.ts
+++ b/stories/Tooltip.stories.ts
@@ -8,13 +8,14 @@ import {
 } from '../projects/ion/src/lib/core/types';
 import { IonTooltipComponent } from '../projects/ion/src/lib/tooltip/tooltip.component';
 import { IonTooltipDirective } from '../projects/ion/src/lib/tooltip/tooltip.directive';
+import { IonIconModule } from '../projects/ion/src/public-api';
 
 export default {
   title: 'Ion/Data Display/Tooltip',
   decorators: [
     moduleMetadata({
       declarations: [IonTooltipDirective, IonTooltipComponent],
-      imports: [CommonModule],
+      imports: [CommonModule, IonIconModule],
       entryComponents: [IonTooltipComponent],
     }),
   ],
@@ -87,3 +88,104 @@ Default.args = {
   ionTooltipTrigger: TooltipTrigger.DEFAULT,
 } as TooltipProps;
 Default.storyName = 'Tooltip';
+
+const WithTemplateRef: Story = (args) => ({
+  props: args,
+  template: `
+    <style>
+        .tooltip {
+            height: 150px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .content {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 8px;
+            color: white;
+        }
+    </style>
+    <div class="tooltip">
+      <span
+        ionTooltip
+        [ionTooltipTemplateRef]="titleTemplate"
+        ionTooltipPosition="${args.ionTooltipPosition}"
+        [ionTooltipArrowPointAtCenter]="${args.ionTooltipArrowPointAtCenter}"
+        ionTooltipColorScheme="${args.ionTooltipColorScheme}"
+        ionTooltipTrigger="${args.ionTooltipTrigger}"
+        ionTooltipShowDelay="${args.ionTooltipShowDelay}"
+      >
+        Hover me
+      </span>
+      <ng-template #titleTemplate>
+        <div class="content">
+          <ion-icon type="check-outlined" color="#FCFCFD"></ion-icon>
+          <span>Verificado!</span>
+        </div>
+      </ng-template>
+    </div>
+  `,
+});
+
+export const WithContent = WithTemplateRef.bind({});
+WithContent.args = {
+  ionTooltipTitle: '',
+  ionTooltipPosition: TooltipPosition.DEFAULT,
+  ionTooltipTrigger: TooltipTrigger.DEFAULT,
+} as TooltipProps;
+WithContent.storyName = 'With Content';
+
+const WithTitleAndTemplateRef: Story = (args) => ({
+  props: args,
+  template: `
+    <style>
+        .tooltip {
+            height: 150px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .content {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 4px;
+            color: white;
+            margin-top: 8px;
+            font-size: 12px;
+        }
+    </style>
+    <div class="tooltip">
+      <span
+        ionTooltip
+        ionTooltipTitle="${args.ionTooltipTitle}"
+        [ionTooltipTemplateRef]="titleTemplate"
+        ionTooltipPosition="${args.ionTooltipPosition}"
+        [ionTooltipArrowPointAtCenter]="${args.ionTooltipArrowPointAtCenter}"
+        ionTooltipColorScheme="${args.ionTooltipColorScheme}"
+        ionTooltipTrigger="${args.ionTooltipTrigger}"
+        ionTooltipShowDelay="${args.ionTooltipShowDelay}"
+      >
+        Hover me
+      </span>
+      <ng-template #titleTemplate>
+        <div class="content">
+          <ion-icon type="wait" size="16" color="#FCFCFD"></ion-icon>
+          <span>Atualizado em 18/04/2022 às 16:34</span>
+        </div>
+      </ng-template>
+    </div>
+  `,
+});
+
+export const WithTitleAndSubtitle = WithTitleAndTemplateRef.bind({});
+WithTitleAndSubtitle.args = {
+  ionTooltipTitle: 'Explicação do indicador aqui',
+  ionTooltipPosition: TooltipPosition.DEFAULT,
+  ionTooltipTrigger: TooltipTrigger.DEFAULT,
+} as TooltipProps;
+WithTitleAndSubtitle.storyName = 'With Title and Content';


### PR DESCRIPTION
Tooltip now receives a TemplateRef, that allow users to insert any type of HTML to be displayed on tooltip. 

![image](https://user-images.githubusercontent.com/57760325/223203426-b80534ff-1083-4825-adc6-06874d6e81eb.png)

It can be used with TooltipTitle to create a "subtitle":

![image](https://user-images.githubusercontent.com/57760325/223203482-339c2b03-f08d-4526-9fb8-c045d0ff523e.png)
