### PR TITLE
style: fix actions colmun header

### DIFF
--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -54,8 +54,9 @@ table {
     padding: spacing(2);
     position: sticky;
     top: 0;
+    z-index: 99;
 
-    & .th-span {
+    & .th-span, &.th-actions {
       font-size: 16px;
       font-weight: 600;
       line-height: 22px;
@@ -63,7 +64,6 @@ table {
     }
 
     &.th-actions {
-      color: $neutral-8;
       text-align: left;
       width: 0%;
     }


### PR DESCRIPTION
#510 

## Description
Actions column header of smart-table have style issues

## Proposed Changes
- set a safe `z-index` on elements inside the table header
- set the same style to `th` tags


## Screenshots
### Before ⬇️ 
![image](https://user-images.githubusercontent.com/45566439/223715766-fef395ad-5284-4eee-a891-86f9a71b7542.png)
### After ⬇️ 
![image](https://user-images.githubusercontent.com/45566439/223734481-628c49b4-5e0f-4405-b99c-588d733564d4.png)


## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.

