### PR TITLE
feat: sidebar group can call an action when clicking on its title

### DIFF
--- a/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.html
@@ -4,6 +4,50 @@
   [class.sidebar-group--selected]="selected"
   [class.sidebar-group--opened]="!closed"
 >
+  <ng-container
+    [ngTemplateOutlet]="haveGroupAction ? headerWithAction : headerClickable"
+  ></ng-container>
+  <ul
+    class="sidebar-group__items"
+    data-testid="sidebar-group__items"
+    [hidden]="closed && !selected"
+  >
+    <ion-sidebar-item
+      *ngFor="let item of items; let i = index"
+      [attr.data-testid]="'sidebar-group__item-' + i"
+      [title]="item.title"
+      [icon]="item.icon"
+      [selected]="item.selected"
+      [disabled]="item.disabled"
+      [hidden]="closed && !item.selected"
+      (atClick)="itemSelected(i)"
+    ></ion-sidebar-item>
+  </ul>
+</section>
+
+<ng-template #headerWithAction>
+  <header
+    class="sidebar-group__header sidebar-group__header--with-action"
+    data-testid="sidebar-group__header"
+  >
+    <div (click)="groupSelected()">
+      <ion-icon
+        data-testid="sidebar-group__title-icon"
+        [type]="icon"
+      ></ion-icon>
+      <span data-testid="sidebar-group__title">{{ title }}</span>
+    </div>
+    <ion-icon
+      class="sidebar-group__toggle-icon"
+      data-testid="sidebar-group__toggle-icon"
+      type="semi-down"
+      size="20"
+      (click)="toggleItemsVisibility()"
+    ></ion-icon>
+  </header>
+</ng-template>
+
+<ng-template #headerClickable>
   <header
     class="sidebar-group__header"
     data-testid="sidebar-group__header"
@@ -23,20 +67,4 @@
       size="20"
     ></ion-icon>
   </header>
-  <ul
-    class="sidebar-group__items"
-    data-testid="sidebar-group__items"
-    [hidden]="closed && !selected"
-  >
-    <ion-sidebar-item
-      *ngFor="let item of items; let i = index"
-      [attr.data-testid]="'sidebar-group__item-' + i"
-      [title]="item.title"
-      [icon]="item.icon"
-      [selected]="item.selected"
-      [disabled]="item.disabled"
-      [hidden]="closed && !item.selected"
-      (atClick)="itemSelected(i)"
-    ></ion-sidebar-item>
-  </ul>
-</section>
+</ng-template>

--- a/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.scss
+++ b/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.scss
@@ -20,12 +20,12 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    cursor: pointer;
     padding: 0 spacing(1);
     color: $primary-color;
     font-weight: 600;
     font-size: 16px;
     line-height: 24px;
+    cursor: pointer;
 
     div {
       display: flex;
@@ -44,6 +44,24 @@
 
   &__toggle-icon {
     transition: all 0.3s ease;
+  }
+
+  &__header--with-action {
+    cursor: initial;
+
+    div {
+      cursor: pointer;
+      transition: all ease-in-out 0.1s;
+
+      &:hover {
+        color: $primary-5;
+        @include icon-color($primary-5);
+      }
+    }
+
+    .sidebar-group__toggle-icon {
+      cursor: pointer;
+    }
   }
 
   &--opened {

--- a/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.spec.ts
+++ b/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.spec.ts
@@ -79,7 +79,7 @@ describe('SidebarGroup', () => {
     expect(getByTestId('items')).not.toBeVisible();
   });
   it('should show items when header is clicked', () => {
-    userEvent.click(getByTestId('header'));
+    userEvent.click(getByTestId('toggleIcon'));
     expect(getByTestId('items')).toBeVisible();
   });
 

--- a/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.ts
@@ -20,7 +20,9 @@ export class IonSidebarGroupComponent implements OnChanges {
   @Input() icon!: IconType;
   @Input() items: Item[] = [];
   @Input() selected = false;
+  @Input() haveGroupAction = false;
   @Output() atClick = new EventEmitter();
+  @Output() atGroupClick = new EventEmitter();
 
   public closed = true;
 
@@ -32,6 +34,10 @@ export class IonSidebarGroupComponent implements OnChanges {
     this.selected = true;
     selectItemByIndex(this.items, itemIndex);
     this.atClick.emit();
+  }
+
+  public groupSelected(): void {
+    this.atGroupClick.emit();
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ion/src/lib/sidebar/sidebar.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar.component.html
@@ -29,7 +29,9 @@
           [icon]="item.icon"
           [selected]="item.selected"
           [items]="item.options"
+          [haveGroupAction]="!!item.action"
           (atClick)="itemOnGroupSelected(i)"
+          (atGroupClick)="groupSelected(i)"
         ></ion-sidebar-group>
       </ng-container>
     </ng-container>

--- a/projects/ion/src/lib/sidebar/sidebar.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar.component.html
@@ -29,7 +29,7 @@
           [icon]="item.icon"
           [selected]="item.selected"
           [items]="item.options"
-          (atClick)="itemSelected(i)"
+          (atClick)="itemOnGroupSelected(i)"
         ></ion-sidebar-group>
       </ng-container>
     </ng-container>

--- a/projects/ion/src/lib/sidebar/sidebar.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { IonSidebarProps } from '../core/types/sidebar';
-import { selectItemByIndex } from './utils';
+import { selectItemByIndex, unselectAllItems } from './utils';
 
 @Component({
   selector: 'ion-sidebar',
@@ -19,5 +19,9 @@ export class IonSidebarComponent {
 
   public itemSelected(itemIndex: number): void {
     selectItemByIndex(this.items, itemIndex);
+  }
+
+  public itemOnGroupSelected(groupIndex: number): void {
+    unselectAllItems(this.items, groupIndex);
   }
 }

--- a/projects/ion/src/lib/sidebar/sidebar.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { IonSidebarProps } from '../core/types/sidebar';
-import { selectItemByIndex, unselectAllItems } from './utils';
+import { selectItemByIndex, callItemAction, unselectAllItems } from './utils';
 
 @Component({
   selector: 'ion-sidebar',
@@ -23,5 +23,10 @@ export class IonSidebarComponent {
 
   public itemOnGroupSelected(groupIndex: number): void {
     unselectAllItems(this.items, groupIndex);
+  }
+
+  public groupSelected(groupIndex: number): void {
+    unselectAllItems(this.items);
+    callItemAction(this.items, groupIndex);
   }
 }

--- a/projects/ion/src/lib/sidebar/sidebar.spec.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.spec.ts
@@ -130,7 +130,7 @@ describe('Sidebar', () => {
       it.each(options)(
         '$title should be visible after clicking on group',
         ({ title: itemTitle }) => {
-          userEvent.click(screen.getByTestId('sidebar-group__header'));
+          userEvent.click(screen.getByTestId('sidebar-group__toggle-icon'));
           expect(screen.getByText(itemTitle)).toBeVisible();
         }
       );
@@ -140,6 +140,7 @@ describe('Sidebar', () => {
       const selectedGroupClass = 'sidebar-group--selected';
       let item1: HTMLElement;
       let item2: HTMLElement;
+      let groupName: HTMLElement;
       let itemGroup2: HTMLElement;
       beforeEach(() => {
         item1 = screen.getByRole('button', {
@@ -148,7 +149,8 @@ describe('Sidebar', () => {
         item2 = screen.getByRole('button', {
           name: items[1].title,
         });
-        userEvent.click(screen.getByTestId('sidebar-group__header'));
+        groupName = screen.getByText('Group 1');
+        userEvent.click(screen.getByTestId('sidebar-group__toggle-icon'));
         itemGroup2 = screen.getByRole('button', {
           name: items[2].options[1].title,
         });
@@ -193,6 +195,42 @@ describe('Sidebar', () => {
         userEvent.click(itemGroup2);
         expect(actionMock).toHaveBeenCalledTimes(1);
       });
+      it('should call action function when click on a group title', () => {
+        userEvent.click(groupName);
+        expect(actionMock).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+  describe('Group without action', () => {
+    beforeEach(async () => {
+      items[2].action = undefined;
+      await sut({ items: [...items], logo });
+      userEvent.click(getByTestId('toggleVisibility').firstElementChild);
+    });
+    describe.each(
+      items
+        .map((item, index) => {
+          return { ...item, index };
+        })
+        .filter((item) => item.options && item.options.length)
+    )('group $title', ({ title, icon, index, options }) => {
+      const defaultGroupTestId = `ion-sidebar__group-${index}`;
+      it(`should render group with ${title}`, () => {
+        expect(screen.getByTestId(defaultGroupTestId)).toHaveTextContent(title);
+      });
+      it(`should render group with icon ${icon}`, () => {
+        const itemIcon = document.getElementById(`ion-icon-${icon}`);
+        expect(screen.getByTestId(defaultGroupTestId)).toContainElement(
+          itemIcon
+        );
+      });
+      it.each(options)(
+        '$title should be visible after clicking on group',
+        ({ title: itemTitle }) => {
+          userEvent.click(screen.getByTestId('sidebar-group__header'));
+          expect(screen.getByText(itemTitle)).toBeVisible();
+        }
+      );
     });
   });
 });

--- a/projects/ion/src/lib/sidebar/sidebar.spec.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.spec.ts
@@ -36,6 +36,7 @@ const items: IonSidebarProps['items'] = [
   {
     title: 'Group 1',
     icon: 'star-solid',
+    action: actionMock,
     options: [
       {
         title: 'Item group 1',

--- a/projects/ion/src/lib/sidebar/sidebar.spec.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.spec.ts
@@ -232,5 +232,9 @@ describe('Sidebar', () => {
         }
       );
     });
+    it('should not call an action when clicking on group title', () => {
+      userEvent.click(screen.getByText('Group 1'));
+      expect(actionMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/projects/ion/src/lib/sidebar/utils.spec.ts
+++ b/projects/ion/src/lib/sidebar/utils.spec.ts
@@ -1,0 +1,28 @@
+import { unselectAllItems } from './utils';
+import { Item } from '../core/types';
+
+const items: Item[] = [
+  { selected: false, title: '', icon: '' },
+  { selected: true, title: '', icon: '' },
+  { selected: false, title: '', icon: '' },
+];
+
+describe('unselectAllItems', () => {
+  it('should deselect all items if no index is provided', () => {
+    unselectAllItems(items);
+    expect(items.every((item) => !item.selected)).toBe(true);
+  });
+
+  it('should deselect all items except the one at the specified index', () => {
+    const exceptItemIndex = 1;
+    unselectAllItems(items, exceptItemIndex);
+    expect(items[exceptItemIndex].selected).toBe(true);
+    expect(items.filter((item) => item.selected).length).toBe(1);
+  });
+
+  it('should not change the selection if an invalid index is provided', () => {
+    const invalidIndex = 10;
+    unselectAllItems(items, invalidIndex);
+    expect(items.every((item) => !item.selected)).toBe(true);
+  });
+});

--- a/projects/ion/src/lib/sidebar/utils.ts
+++ b/projects/ion/src/lib/sidebar/utils.ts
@@ -4,7 +4,7 @@ function selectItem(items: Item[], index: number): void {
   items[index].selected = true;
 }
 
-function callItemAction(items: Item[], index: number): void {
+export function callItemAction(items: Item[], index: number): void {
   if (items[index].action) {
     items[index].action();
   }

--- a/projects/ion/src/lib/sidebar/utils.ts
+++ b/projects/ion/src/lib/sidebar/utils.ts
@@ -10,12 +10,14 @@ export function callItemAction(items: Item[], index: number): void {
   }
 }
 
-export function unselectAllItems(items: Item[], exceptItemIndex = -1): void {
-  items.forEach((item) => (item.selected = false));
-
-  if (exceptItemIndex >= 0) {
-    items[exceptItemIndex].selected = true;
-  }
+export function unselectAllItems(
+  items: Item[],
+  exceptItemIndex?: number
+): void {
+  items.forEach((item, index) => {
+    item.selected =
+      exceptItemIndex !== undefined ? index === exceptItemIndex : false;
+  });
 }
 
 export function selectItemByIndex(items: Item[], itemIndex: number): Item[] {

--- a/projects/ion/src/lib/sidebar/utils.ts
+++ b/projects/ion/src/lib/sidebar/utils.ts
@@ -10,8 +10,12 @@ function callItemAction(items: Item[], index: number): void {
   }
 }
 
-export function unselectAllItems(items: Item[]): void {
+export function unselectAllItems(items: Item[], exceptItemIndex = -1): void {
   items.forEach((item) => (item.selected = false));
+
+  if (exceptItemIndex >= 0) {
+    items[exceptItemIndex].selected = true;
+  }
 }
 
 export function selectItemByIndex(items: Item[], itemIndex: number): Item[] {

--- a/stories/Sidebar.stories.ts
+++ b/stories/Sidebar.stories.ts
@@ -41,6 +41,34 @@ Default.args = {
     {
       title: 'Permissões',
       icon: 'config',
+      action: action('Permissões'),
+      options: [
+        {
+          title: 'Gerência',
+          icon: 'user',
+          action: action('Gerência'),
+        },
+        {
+          title: 'Grupos',
+          icon: 'union',
+          action: action('Grupos'),
+        },
+        {
+          title: 'Pausas',
+          icon: 'wait',
+          action: action('Pausas'),
+        },
+        {
+          title: 'Comissões',
+          icon: 'calendar-money',
+          action: action('Comissões'),
+          disabled: true,
+        },
+      ],
+    },
+    {
+      title: 'Gerenciamento',
+      icon: 'working',
       options: [
         {
           title: 'Gerência',


### PR DESCRIPTION
When a sidebar group has an action, this action will be called when the title in the header is clicked. The user will be able to toggle the group when clicking on the arrow icon.

[Screencast from 09-03-2023 13:18:51.webm](https://user-images.githubusercontent.com/57760325/224086328-f97eb77f-03eb-4368-b0be-7fc2680c6692.webm)

---
When a sidebar group doesn't have an action, the user will be able to toggle the group clicking on header, not just on the arrow icon.

[Screencast from 09-03-2023 13:19:21.webm](https://user-images.githubusercontent.com/57760325/224086494-ec0eb0de-130d-4736-81d2-c7b6316def3c.webm)

(Both examples are available on Storybook)