### PR TITLE
fix: showing clear button when there are selected values by default

### DIFF
--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -112,7 +112,7 @@ describe('Dropdown / Clear Filters', () => {
       expect(elementToSelect).not.toHaveClass('dropdown-item-selected');
     });
 
-    it('should button disapear when filter is not selected', async () => {
+    it('button should not be visible when filter is not selected', async () => {
       expect(elementToSelect).toHaveClass('dropdown-item-selected');
       fireEvent.click(screen.getByTestId('buttonClear'));
       expect(elementToSelect).not.toHaveClass('dropdown-item-selected');

--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -82,29 +82,42 @@ describe('Dropdown / Clear Filters', () => {
   const optionToSelect = 0;
   let elementToSelect;
 
-  beforeEach(async () => {
-    await sut();
-    selectEvent.mockClear();
-    elementToSelect = document.getElementById('option-' + optionToSelect);
-    fireEvent.click(elementToSelect);
-  });
-
-  it('should render button to clear filters selected in dropdown', async () => {
-    expect(elementToSelect).toHaveClass('dropdown-item-selected');
+  it('should render clear button on init if there are selected values by default', async () => {
+    await sut({
+      ...defaultDropdown,
+      options: [
+        { label: 'Option 1', selected: true },
+        { label: 'Option 2', selected: false },
+      ],
+    });
     expect(screen.getByTestId('buttonClear')).toBeInTheDocument();
   });
 
-  it('should clear filters selected in dropdown', async () => {
-    expect(elementToSelect).toHaveClass('dropdown-item-selected');
-    fireEvent.click(screen.getByTestId('buttonClear'));
-    expect(elementToSelect).not.toHaveClass('dropdown-item-selected');
-  });
+  describe('events', () => {
+    beforeEach(async () => {
+      await sut();
+      selectEvent.mockClear();
+      elementToSelect = document.getElementById('option-' + optionToSelect);
+      fireEvent.click(elementToSelect);
+    });
 
-  it('should button disapear when filter is not selected', async () => {
-    expect(elementToSelect).toHaveClass('dropdown-item-selected');
-    fireEvent.click(screen.getByTestId('buttonClear'));
-    expect(elementToSelect).not.toHaveClass('dropdown-item-selected');
-    expect(screen.queryByText('Limpar')).not.toBeInTheDocument();
+    it('should render button to clear filters selected in dropdown', async () => {
+      expect(elementToSelect).toHaveClass('dropdown-item-selected');
+      expect(screen.getByTestId('buttonClear')).toBeInTheDocument();
+    });
+
+    it('should clear filters selected in dropdown', async () => {
+      expect(elementToSelect).toHaveClass('dropdown-item-selected');
+      fireEvent.click(screen.getByTestId('buttonClear'));
+      expect(elementToSelect).not.toHaveClass('dropdown-item-selected');
+    });
+
+    it('should button disapear when filter is not selected', async () => {
+      expect(elementToSelect).toHaveClass('dropdown-item-selected');
+      fireEvent.click(screen.getByTestId('buttonClear'));
+      expect(elementToSelect).not.toHaveClass('dropdown-item-selected');
+      expect(screen.queryByText('Limpar')).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnInit,
   Output,
 } from '@angular/core';
 import { DropdownItem, DropdownParams } from '../core/types/dropdown';
@@ -12,7 +13,7 @@ import { DropdownItem, DropdownParams } from '../core/types/dropdown';
   templateUrl: './dropdown.component.html',
   styleUrls: ['./dropdown.component.scss'],
 })
-export class IonDropdownComponent implements AfterViewInit {
+export class IonDropdownComponent implements OnInit, AfterViewInit {
   @Input() options: DropdownItem[];
   @Input() multiple?: DropdownParams['multiple'] = false;
   @Input() enableSearch = false;
@@ -83,5 +84,9 @@ export class IonDropdownComponent implements AfterViewInit {
 
   private isSingle(): boolean {
     return !this.multiple;
+  }
+
+  public ngOnInit(): void {
+    this.setClearButtonIsVisible();
   }
 }

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -78,15 +78,15 @@ export class IonDropdownComponent implements OnInit, AfterViewInit {
     this.searchChange.emit(value);
   }
 
+  public ngOnInit(): void {
+    this.setClearButtonIsVisible();
+  }
+
   private isDisabled(option: DropdownItem): boolean {
     return option.disabled;
   }
 
   private isSingle(): boolean {
     return !this.multiple;
-  }
-
-  public ngOnInit(): void {
-    this.setClearButtonIsVisible();
   }
 }


### PR DESCRIPTION
## Description

showing clear button when there are selected values by default

## Proposed Changes
set clear button visibility on init

### Expected Behavior
![image](https://user-images.githubusercontent.com/65717646/229120762-bd32e797-5b84-4505-9964-7baa0c6731b5.png)

### Current Behavior
![image](https://user-images.githubusercontent.com/65717646/229120632-94278b03-3678-471d-ae78-ebc7e81feaf7.png)

## How to Test
The storybook had some rendering bugs that make visual tests a bit difficult, so to test I created a stories.ts (that has not been committed) with a mock @component to render the dropdown inside it and work around these storybook bugs

## Screenshots
results in dropdown rendered inside mock test component:
![Captura de tela de 2023-03-31 10-01-19](https://user-images.githubusercontent.com/90062413/229129020-71dabb19-f90c-46f7-ba01-5d6fbd29a70b.png)

## Compliance
- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
