### PR TITLE
fix: adjustments to improove and fix some behaviors at pagination

### DIFF
--- a/projects/ion/src/lib/button/button.component.scss
+++ b/projects/ion/src/lib/button/button.component.scss
@@ -366,6 +366,10 @@ button {
 }
 
 .ion-btn-dropdown {
-  margin-top: 4px;
+  z-index: 999;
   position: relative;
+
+  ::ng-deep .container-options {
+    margin-top: 4px;
+  }
 }

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -79,8 +79,8 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   }
 
   hasPrevious(): boolean {
-    const fisrtPage = this.inFirstPage();
-    return fisrtPage !== undefined && fisrtPage !== null && !fisrtPage;
+    const firstPage = this.inFirstPage();
+    return firstPage !== undefined && firstPage !== null && !firstPage;
   }
 
   hasNext(): boolean {

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -79,7 +79,8 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   }
 
   hasPrevious(): boolean {
-    return !this.inFirstPage();
+    const fisrtPage = this.inFirstPage();
+    return fisrtPage !== undefined && fisrtPage !== null && !fisrtPage;
   }
 
   hasNext(): boolean {
@@ -101,7 +102,7 @@ export class IonPaginationComponent implements OnChanges, OnInit {
 
   remountPages(): void {
     this.createPages(this.totalPages());
-    this.selectPage(1);
+    if (this.pages.length) this.selectPage(1);
   }
 
   totalPages(): number {
@@ -129,11 +130,13 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   }
 
   private inLastPage(): boolean {
-    return this.currentPage().page_number === this.totalPages();
+    const currentPageCopy = this.currentPage();
+    return currentPageCopy && currentPageCopy.page_number === this.totalPages();
   }
 
   private inFirstPage(): boolean {
-    return this.currentPage().page_number === 1;
+    const currentPageCopy = this.currentPage();
+    return currentPageCopy && currentPageCopy.page_number === 1;
   }
 
   private generateLabel(page: number): string {

--- a/projects/ion/src/lib/smart-table/smart-table.component.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.ts
@@ -116,7 +116,6 @@ export class IonSmartTableComponent implements OnInit {
 
   public paginationEvents(event: PageEvent): void {
     this.pagination = event;
-    this.config.pagination.page = this.pagination.actual;
     if (!this.config.loading && !this.firstLoad) {
       this.events.emit({
         event: EventTable.CHANGE_PAGE,

--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -56,7 +56,8 @@ table {
     top: 0;
     z-index: 99;
 
-    & .th-span, &.th-actions {
+    & .th-span,
+    &.th-actions {
       font-size: 16px;
       font-weight: 600;
       line-height: 22px;
@@ -137,6 +138,7 @@ table {
   justify-content: space-between;
   padding: 16px;
   gap: spacing(2);
+  z-index: 900;
 
   position: sticky;
   bottom: 0;

--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -53,7 +53,7 @@ table {
     padding: spacing(2);
     position: sticky;
     top: 0;
-    z-index: 99;
+    z-index: $zIndexMid;
 
     & .th-span,
     &.th-actions {
@@ -141,7 +141,7 @@ table {
   justify-content: space-between;
   padding: 16px;
   gap: spacing(2);
-  z-index: 900;
+  z-index: $zIndexLow;
 
   position: sticky;
   bottom: 0;


### PR DESCRIPTION
## Description

When using pagination component in a project, through the SmatTable component, some behaviors  that need to be resolved were noticed:

- When selecting a number of items per page, the option selector appears broken in the layout;
- Also, it has a strange behavior over the table, causing the table footer to jitter slightly when I open the selector.


## Expected Behavior

- That selector for the number of items per page is completely visible;
- That selector is usable, even when placed at the bottom of a page, opening the options upwards.


## Screenshots

![Captura de tela de 2023-03-28 16-13-41](https://user-images.githubusercontent.com/63553747/228544022-93f5fa2c-92d8-4552-bb0b-c2e16e42187b.png)

## Additional Information

There are two other notes about pagination involving the table, so I'll leave them on record as another issue to resolve, leaving them here for informational purposes only:

- When pagination receives 0 as the total items value, it disappears;
- When using paging, the table is returning two Output emissions, causing the page to call data listing route twice instead of once.
