### PR TITLE
fix: adding validation of changes to the label

### DIFF
--- a/projects/ion/src/lib/chip/chip.component.html
+++ b/projects/ion/src/lib/chip/chip.component.html
@@ -18,7 +18,6 @@
   <div
     data-testid="ion-chip-label"
     class="container-icon-text"
-    id="ion-chip-label"
     [ngClass]="{
       positionIcon: iconPosition === 'left' && icon && !options
     }"

--- a/projects/ion/src/lib/chip/chip.component.html
+++ b/projects/ion/src/lib/chip/chip.component.html
@@ -16,7 +16,9 @@
   ></ion-badge>
 
   <div
+    data-testid="ion-chip-label"
     class="container-icon-text"
+    id="ion-chip-label"
     [ngClass]="{
       positionIcon: iconPosition === 'left' && icon && !options
     }"

--- a/projects/ion/src/lib/chip/chip.component.spec.ts
+++ b/projects/ion/src/lib/chip/chip.component.spec.ts
@@ -117,7 +117,7 @@ describe('ChipComponent', () => {
     expect(screen.getByText(labelBadge)).toBeInTheDocument();
   });
 
-  it('should test if a dropdown component correctly updates label', async () => {
+  it('should correctly updates label when the selected option changes', async () => {
     const dropdownEvent = jest.fn();
     const customOptions = [
       { label: 'Slytherin', selected: true },

--- a/projects/ion/src/lib/chip/chip.component.spec.ts
+++ b/projects/ion/src/lib/chip/chip.component.spec.ts
@@ -1,4 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/angular';
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+} from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { IonBadgeModule } from '../badge/badge.module';
 import { IonDropdownModule } from '../dropdown/dropdown.module';
@@ -12,11 +17,14 @@ import {
   IconDirection,
 } from './chip.component';
 import { InfoBadgeStatus } from '../core/types';
+import { SimpleChange } from '@angular/core';
 
 const defaultOptions = [{ label: 'Cat' }, { label: 'Dog' }];
 
-const sut = async (customProps?: IonChipProps): Promise<void> => {
-  await render(ChipComponent, {
+const sut = async (
+  customProps?: IonChipProps
+): Promise<RenderResult<ChipComponent>> => {
+  return await render(ChipComponent, {
     componentProperties: customProps || {
       label: 'chip',
     },
@@ -107,6 +115,37 @@ describe('ChipComponent', () => {
       rightBadge: { label: labelBadge, type: 'negative' },
     });
     expect(screen.getByText(labelBadge)).toBeInTheDocument();
+  });
+
+  it('should test if a dropdown component correctly updates label', async () => {
+    const dropdownEvent = jest.fn();
+    const customOptions = [
+      { label: 'Slytherin', selected: true },
+      { label: 'Ravenclaw', selected: false },
+    ];
+    const customProps = {
+      label: 'dropdown',
+      options: customOptions,
+      multiple: false,
+      dropdownEvents: {
+        emit: dropdownEvent,
+      } as SafeAny,
+    };
+    const { fixture } = await sut(customProps);
+    expect(screen.getByTestId('ion-chip-label')).toHaveTextContent(
+      customOptions[0].label
+    );
+    const element = screen.getByTestId('ion-chip');
+    fireEvent.click(element);
+    fireEvent.click(document.getElementById('option-0'));
+    customProps.options[0].selected = false;
+    customProps.options[1].selected = true;
+
+    fixture.componentInstance.ngOnChanges({
+      options: new SimpleChange(null, customProps.options, false),
+    });
+    fixture.detectChanges();
+    expect(fixture.componentInstance.label).toBe(customProps.options[1].label);
   });
 
   describe('With Dropdown', () => {

--- a/projects/ion/src/lib/chip/chip.component.ts
+++ b/projects/ion/src/lib/chip/chip.component.ts
@@ -6,6 +6,8 @@ import {
   Input,
   Output,
   OnInit,
+  OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import {
   BadgeType,
@@ -56,7 +58,7 @@ interface RightBadge {
   styleUrls: ['./chip.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ChipComponent implements OnInit {
+export class ChipComponent implements OnInit, OnChanges {
   @Input() label!: string;
   @Input() disabled = false;
   @Input() selected = false;
@@ -133,6 +135,15 @@ export class ChipComponent implements OnInit {
     }
 
     this.label = selectedOption.label;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.options && !changes.options.firstChange && !this.multiple) {
+      const filtroSelection = changes.options.currentValue.filter(
+        (option: DropdownItem) => option.selected
+      );
+      this.label = filtroSelection[0].label;
+    }
   }
 
   getSelectedOptions(): DropdownItem[] {

--- a/projects/ion/src/lib/chip/chip.component.ts
+++ b/projects/ion/src/lib/chip/chip.component.ts
@@ -139,10 +139,10 @@ export class ChipComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.options && !changes.options.firstChange && !this.multiple) {
-      const filtroSelection = changes.options.currentValue.filter(
+      const filterSelection = changes.options.currentValue.filter(
         (option: DropdownItem) => option.selected
       );
-      this.label = filtroSelection[0].label;
+      this.label = filterSelection[0].label;
     }
   }
 


### PR DESCRIPTION
## Description

Validation was added to ngOnChanges for the chip to change the label when the dropdown options are changed via TS
### before
![image (1)](https://user-images.githubusercontent.com/60994870/229858510-1e497c5e-e7ae-4be9-ae98-cec705f49edd.png)

### after
![image](https://user-images.githubusercontent.com/60994870/229858782-6f5a348e-d7a4-4648-9045-769a7da28342.png)

