### PR TITLE
feat: apply z-index pattern at overly elements

### DIFF
--- a/projects/ion/package.json
+++ b/projects/ion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brisanet/ion",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "peerDependencies": {
     "@angular/common": "^8.1.3",
     "@angular/core": "^8.1.3"

--- a/projects/ion/src/lib/dropdown/dropdown.component.scss
+++ b/projects/ion/src/lib/dropdown/dropdown.component.scss
@@ -86,7 +86,7 @@
 
 .container-options {
   position: absolute;
-  z-index: 10;
+  z-index: $zIndexLow;
   display: flex;
   flex-direction: column;
   gap: spacing(0.5);

--- a/projects/ion/src/lib/dropdown/dropdown.component.scss
+++ b/projects/ion/src/lib/dropdown/dropdown.component.scss
@@ -86,6 +86,7 @@
 
 .container-options {
   position: absolute;
+  z-index: 10;
   display: flex;
   flex-direction: column;
   gap: spacing(0.5);

--- a/projects/ion/src/lib/message/message.component.scss
+++ b/projects/ion/src/lib/message/message.component.scss
@@ -9,7 +9,7 @@
   display: flex;
   gap: spacing(2);
   position: relative;
-  z-index: 999;
+  z-index: $zIndexMax;
   box-shadow: 0px 8px 6px -4px rgb(0 0 0 / 15%), 0px 0px 2px rgb(0 0 0 / 15%);
   font-size: 14px;
   line-height: 20px;

--- a/projects/ion/src/lib/message/message.component.scss
+++ b/projects/ion/src/lib/message/message.component.scss
@@ -8,6 +8,8 @@
 .ion-message {
   display: flex;
   gap: spacing(2);
+  position: relative;
+  z-index: 999;
   box-shadow: 0px 8px 6px -4px rgb(0 0 0 / 15%), 0px 0px 2px rgb(0 0 0 / 15%);
   font-size: 14px;
   line-height: 20px;

--- a/projects/ion/src/lib/modal/component/modal.component.scss
+++ b/projects/ion/src/lib/modal/component/modal.component.scss
@@ -6,7 +6,7 @@
 }
 
 .modal-overlay {
-  z-index: 100;
+  z-index: $zIndexMid;
   position: absolute;
   top: 0;
   left: 0;

--- a/projects/ion/src/lib/modal/component/modal.component.scss
+++ b/projects/ion/src/lib/modal/component/modal.component.scss
@@ -6,7 +6,7 @@
 }
 
 .modal-overlay {
-  z-index: 99;
+  z-index: 100;
   position: absolute;
   top: 0;
   left: 0;

--- a/projects/ion/src/lib/notification/notification.component.scss
+++ b/projects/ion/src/lib/notification/notification.component.scss
@@ -13,6 +13,8 @@
   align-items: flex-start;
   justify-content: space-between;
   padding: spacing(1.5) spacing(2);
+  position: relative;
+  z-index: 999;
 
   background: rgba(255, 255, 255, 0.9);
   box-shadow: 0px 8px 6px -4px rgba(0, 0, 0, 0.15),

--- a/projects/ion/src/lib/notification/notification.component.scss
+++ b/projects/ion/src/lib/notification/notification.component.scss
@@ -14,7 +14,7 @@
   justify-content: space-between;
   padding: spacing(1.5) spacing(2);
   position: relative;
-  z-index: 999;
+  z-index: $zIndexMax;
 
   background: rgba(255, 255, 255, 0.9);
   box-shadow: 0px 8px 6px -4px rgba(0, 0, 0, 0.15),

--- a/projects/ion/src/lib/popconfirm/popconfirm.component.scss
+++ b/projects/ion/src/lib/popconfirm/popconfirm.component.scss
@@ -36,7 +36,7 @@
 }
 
 .containter {
-  z-index: 10;
+  z-index: $zIndexLow;
 }
 
 .description {

--- a/projects/ion/src/lib/popconfirm/popconfirm.component.scss
+++ b/projects/ion/src/lib/popconfirm/popconfirm.component.scss
@@ -36,7 +36,7 @@
 }
 
 .containter {
-  z-index: 1000;
+  z-index: 10;
 }
 
 .description {

--- a/projects/ion/src/lib/popover/component/popover.component.scss
+++ b/projects/ion/src/lib/popover/component/popover.component.scss
@@ -113,7 +113,7 @@ $arrow-size: 4.5px;
 }
 
 .container {
-  z-index: 10;
+  z-index: $zIndexLow;
 }
 
 .header {

--- a/projects/ion/src/lib/popover/component/popover.component.scss
+++ b/projects/ion/src/lib/popover/component/popover.component.scss
@@ -113,7 +113,7 @@ $arrow-size: 4.5px;
 }
 
 .container {
-  z-index: 1000;
+  z-index: 10;
 }
 
 .header {

--- a/projects/ion/src/lib/tooltip/tooltip.component.scss
+++ b/projects/ion/src/lib/tooltip/tooltip.component.scss
@@ -28,7 +28,7 @@ $arrow-size: 4.2px;
 }
 
 .ion-tooltip {
-  z-index: 10;
+  z-index: $nzIndexLow;
   position: fixed;
   padding: spacing(1);
   overflow-wrap: break-word;

--- a/projects/ion/src/lib/tooltip/tooltip.component.scss
+++ b/projects/ion/src/lib/tooltip/tooltip.component.scss
@@ -28,7 +28,7 @@ $arrow-size: 4.2px;
 }
 
 .ion-tooltip {
-  z-index: 100;
+  z-index: 10;
   position: fixed;
   padding: spacing(1);
   overflow-wrap: break-word;

--- a/projects/ion/src/lib/tooltip/tooltip.component.scss
+++ b/projects/ion/src/lib/tooltip/tooltip.component.scss
@@ -28,7 +28,7 @@ $arrow-size: 4.2px;
 }
 
 .ion-tooltip {
-  z-index: $nzIndexLow;
+  z-index: $zIndexLow;
   position: fixed;
   padding: spacing(1);
   overflow-wrap: break-word;

--- a/projects/ion/src/styles/index.scss
+++ b/projects/ion/src/styles/index.scss
@@ -2,3 +2,4 @@
 @import 'themes/index.scss';
 @import 'fonts/index.scss';
 @import 'shadows/index.scss';
+@import 'z-indexes/index.scss';

--- a/projects/ion/src/styles/z-indexes/index.scss
+++ b/projects/ion/src/styles/z-indexes/index.scss
@@ -1,0 +1,3 @@
+$zIndexLow: 10;
+$zIndexMid: 100;
+$zIndexMax: 999;


### PR DESCRIPTION
## Description

Apply z-index pattern to elements that float on the screen, overlapping other components.

## Expected Behavior

Avoid randomly choosing z-indez for components, which could lead to some strange behavior, such as a dropdown appearing below other elements on the screen, when it should actually appear above them.

Below is an image with expected z-index values for the listed elements, categorized by levels:

![Nível Hierárquico dos componentes](https://user-images.githubusercontent.com/63553747/230097162-fca49dcd-5f88-4e81-b5a8-f0b17a66e5fc.jpg)

## Current Behavior

List of elements and their current z-index:

- Modal: 99
- Message: (Não há)
- Dropdown: (Não há)
- Notification: (Não há)
- Popconfirm: 1.000 (O valor máximo é 999)
- Popover: 1.000 (O valor máximo é 999)
- Tooltip: 100