### PR TITLE
fix: fixing break a line

### DIFF
--- a/projects/ion/src/lib/chip/chip.component.scss
+++ b/projects/ion/src/lib/chip/chip.component.scss
@@ -125,6 +125,7 @@ button {
 .container-icon-text {
   display: flex;
   align-items: center;
+  white-space: nowrap;
   gap: spacing(1);
 }
 


### PR DESCRIPTION
## Description

when the space available for the chip was reduced, it would break the line, so I implemented the "white-space: nowrap;" styling. to fix that so it keeps the original size

`.container-icon-text {
  display: flex;
  align-items: center;
  white-space: nowrap;
  gap: spacing(1);
}`

## Screenshots

before: 
![image](https://user-images.githubusercontent.com/93842972/230387816-51fef49c-4169-4125-918c-7a242ea9f4a9.png)

after: 
![image](https://user-images.githubusercontent.com/93842972/230387881-13aaf400-a29c-418b-a60b-2667590e7cf6.png)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.

reference: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space

