### PR TITLE
fix: size adjustment when there is one digit (#572)

### DIFF
--- a/projects/ion/src/lib/badge/badge.component.scss
+++ b/projects/ion/src/lib/badge/badge.component.scss
@@ -2,6 +2,7 @@
 
 .ion-badge {
   display: flex;
+  text-align: center;
 
   span {
     font-family: 'Source Sans Pro', sans-serif;
@@ -10,6 +11,7 @@
     line-height: 16px;
     padding: spacing(0) spacing(0.5);
     border-radius: 50px;
+    min-width: 8px;
   }
 }
 


### PR DESCRIPTION
## Description
I added a min width to the span so that the size adjusts when there is only one digit.

## Screenshots
![Captura de tela de 2023-04-10 12-08-56](https://user-images.githubusercontent.com/81201377/230929381-ac069f79-f798-40f0-a191-3e01fe7a9bc0.png)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.