### PR TITLE
fix: popconfirm on footer table css :ambulance: #587

### DIFF
--- a/projects/ion/src/lib/popconfirm/popconfirm.component.scss
+++ b/projects/ion/src/lib/popconfirm/popconfirm.component.scss
@@ -9,7 +9,8 @@
   justify-content: flex-end;
   border-radius: spacing(1);
   position: relative;
-  
+  z-index: $zIndexLow;
+
   &::before {
     content: '';
     display: block;

--- a/stories/Table.stories.ts
+++ b/stories/Table.stories.ts
@@ -209,6 +209,7 @@ WithPagination.args = {
       total: 46,
       itemsPerPage: 2,
     },
+    actions,
   },
 };
 


### PR DESCRIPTION
fixed #587 css z-index on popconfirm.

<img width="310" alt="image" src="https://user-images.githubusercontent.com/6165180/231259868-ece46718-44eb-4566-94f1-7f5ee2dfa9d7.png">