### PR TITLE
feat: ellipsis in pagination component (#512)

### DIFF
--- a/projects/ion/src/lib/pagination/pagination.component.html
+++ b/projects/ion/src/lib/pagination/pagination.component.html
@@ -18,16 +18,24 @@
     [disabled]="loading || !hasPrevious()"
   ></ion-button>
 
-  <button
-    *ngFor="let page of pages"
-    [class]="'square-pag ' + 'page-' + size"
-    [class.selected]="page.selected"
-    [attr.data-testid]="'page-' + page.page_number"
-    (click)="!loading && selectPage(page.page_number)"
-    [class.disabled]="loading"
-  >
-    <span>{{ page.page_number }}</span>
-  </button>
+  <ng-container *ngFor="let page of pages">
+    <button
+      [class]="
+        'square-pag ' + 'page-' + size + ' page-number-' + page.page_number
+      "
+      *ngIf="!hidePages(page.page_number)"
+      [class.selected]="page.selected"
+      [attr.data-testid]="'page-' + page.page_number"
+      (click)="!loading && selectPage(page.page_number)"
+      [class.disabled]="loading"
+    >
+      <span [class]="'page-ellipsis-' + page.page_number">{{
+        page.page_number === -1 || page.page_number === 0
+          ? '...'
+          : page.page_number
+      }}</span>
+    </button>
+  </ng-container>
 
   <ion-button
     iconType="right2"

--- a/projects/ion/src/lib/pagination/pagination.component.scss
+++ b/projects/ion/src/lib/pagination/pagination.component.scss
@@ -12,6 +12,43 @@
   border-radius: $borderRadius;
 }
 
+@mixin setBackgroundRightEllipsis($color) {
+  background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='%23" + $color + "' d='M17.8839 12.8839C18.1183 12.6495 18.25 12.3315 18.25 12C18.25 11.6685 18.1183 11.3505 17.8839 11.1161L13.8839 7.11612C13.3957 6.62796 12.6043 6.62796 12.1161 7.11612C11.628 7.60427 11.628 8.39573 12.1161 8.88388L15.2322 12L12.1161 15.1161C11.628 15.6043 11.628 16.3957 12.1161 16.8839C12.6043 17.372 13.3957 17.372 13.8839 16.8839L17.8839 12.8839Z'/><path fill='%23" + $color + "' d='M11.8839 12.8839C12.1183 12.6495 12.25 12.3315 12.25 12C12.25 11.6685 12.1183 11.3505 11.8839 11.1161L7.88388 7.11612C7.39573 6.62796 6.60427 6.62796 6.11612 7.11612C5.62796 7.60427 5.62796 8.39573 6.11612 8.88388L9.23223 12L6.11612 15.1161C5.62796 15.6043 5.62796 16.3957 6.11612 16.8839C6.60427 17.372 7.39573 17.372 7.88388 16.8839L11.8839 12.8839Z'/></svg>");
+ }
+
+@mixin setBackgroundLeftEllipsis($color) {
+  background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='%23" + $color + "' d='M6.11612 11.1161C5.8817 11.3505 5.75 11.6685 5.75 12C5.75 12.3315 5.8817 12.6495 6.11612 12.8839L10.1161 16.8839C10.6043 17.372 11.3957 17.372 11.8839 16.8839C12.372 16.3957 12.372 15.6043 11.8839 15.1161L8.76777 12L11.8839 8.88388C12.372 8.39573 12.372 7.60427 11.8839 7.11612C11.3957 6.62796 10.6043 6.62796 10.1161 7.11612L6.11612 11.1161Z'/><path fill='%23" + $color + "' d='M12.1161 11.1161C11.8817 11.3505 11.75 11.6685 11.75 12C11.75 12.3315 11.8817 12.6495 12.1161 12.8839L16.1161 16.8839C16.6043 17.372 17.3957 17.372 17.8839 16.8839C18.372 16.3957 18.372 15.6043 17.8839 15.1161L14.7678 12L17.8839 8.88388C18.372 8.39573 18.372 7.60427 17.8839 7.11612C17.3957 6.62796 16.6043 6.62796 16.1161 7.11612L12.1161 11.1161Z'/></svg>");
+}
+
+$color-primary-5: '146ff5';
+
+@mixin hoverEllipsisConfig($ellipsisType) {
+  display: inline-block;
+  position: relative;
+
+  .square-pag:hover & {
+    color: transparent;
+
+    &::before {
+      @if $ellipsisType == "first" {
+        @include setBackgroundLeftEllipsis($color-primary-5);
+      } @else if $ellipsisType == "secondary" {
+        @include setBackgroundRightEllipsis($color-primary-5);
+      }
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-size: cover;
+      background-position: center center;
+      background-repeat: no-repeat;
+    }
+  }
+}
+
 .pag-container {
   display: flex;
   align-items: flex-start;
@@ -68,4 +105,12 @@
   &:hover {
     @include setBorderBgColor($neutral-5, $neutral-3, $neutral-5);
   }
+}
+
+.page-ellipsis--1 {
+  @include hoverEllipsisConfig('first');
+}
+
+.page-ellipsis-0 {
+  @include hoverEllipsisConfig('secondary');
 }

--- a/projects/ion/src/lib/pagination/pagination.component.spec.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.spec.ts
@@ -137,3 +137,47 @@ describe('Pagination > Events', () => {
     expect(screen.queryAllByText('20 / página')).toHaveLength(1);
   });
 });
+
+describe('PaginationComponent with Ellipsis', () => {
+  it('should not to be selected when it is clicked', async () => {
+    await sut({
+      total: 23,
+      itemsPerPage: 1,
+    });
+    const pageZero = screen.getByTestId('page-0');
+    fireEvent.click(pageZero);
+    expect(pageZero).not.toHaveClass('selected');
+  });
+
+  it('should render the first ellipsis when page five is selected and render a page two when ellipsis is clicked', async () => {
+    await sut({
+      total: 46,
+      itemsPerPage: 2,
+    });
+    const pageFive = screen.getByTestId('page-5');
+    fireEvent.click(pageFive);
+    const firstEllipsis = screen.getByTestId('page--1');
+    fireEvent.click(firstEllipsis);
+    expect(document.querySelectorAll('.square-pag')).toHaveLength(7);
+  });
+
+  it('should render up to five pages more when the second ellipsis is clicked', async () => {
+    await sut({
+      total: 46,
+      itemsPerPage: 2,
+    });
+    const pageZero = screen.getByTestId('page-0');
+    fireEvent.click(pageZero);
+    expect(document.querySelectorAll('.square-pag')).toHaveLength(9);
+  });
+
+  it('should render a first ellipsis when last page is selected', async () => {
+    await sut({
+      total: 46,
+      itemsPerPage: 2,
+    });
+    const lastPage = screen.getByTestId('page-23');
+    fireEvent.click(lastPage);
+    expect(lastPage).toHaveClass('selected');
+  });
+});

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -12,7 +12,7 @@ import { IonPaginationProps, Page, PageEvent } from '../core/types/pagination';
 import { IonPaginationEllipsisComponent } from './utils/ellipsis.component';
 export const ITEMS_PER_PAGE_DEFAULT = 10;
 export const LIST_OF_PAGE_OPTIONS = [10, 20, 30, 40, 46];
-
+export const LIMIT_TO_ADVANCED_PAGINATION = 10;
 @Component({
   selector: 'ion-pagination',
   templateUrl: './pagination.component.html',
@@ -117,7 +117,7 @@ export class IonPaginationComponent implements OnChanges, OnInit {
 
   selectedPageCondition(pageNumber: number): void {
     let page: Page;
-    if (this.totalPages() >= 10) {
+    if (this.totalPages() >= LIMIT_TO_ADVANCED_PAGINATION) {
       page = this.pages[this.paginationEllipsis.skipEllipsis(pageNumber)];
       pageNumber === 0 || pageNumber === -1
         ? (page.selected = false)
@@ -146,7 +146,7 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   private createPages(qtdOfPages: number): void {
     this.pages = [];
     for (let index = 0; index < qtdOfPages; index++) {
-      if (qtdOfPages >= 10) {
+      if (qtdOfPages >= LIMIT_TO_ADVANCED_PAGINATION) {
         this.paginationEllipsis.createEllipsis(index, qtdOfPages);
       } else {
         this.pages.push({

--- a/projects/ion/src/lib/pagination/utils/ellipsis.component.ts
+++ b/projects/ion/src/lib/pagination/utils/ellipsis.component.ts
@@ -1,0 +1,110 @@
+import { IonPaginationComponent } from '../pagination.component';
+
+export interface Limit {
+  leftLimit: number;
+  showLeftEllipsis: boolean;
+  firstPages: boolean;
+}
+export class IonPaginationEllipsisComponent {
+  constructor(private paginationComponent: IonPaginationComponent) {}
+
+  createEllipsis(index: number, qtdOfPages: number): void {
+    if (index === 1) {
+      this.createBothEllipsis(-1);
+    } else if (index === qtdOfPages - 1) {
+      this.createBothEllipsis(0);
+    }
+    this.paginationComponent.pages.push({
+      selected: false,
+      page_number: index + 1,
+    });
+  }
+
+  createBothEllipsis(number: number): number {
+    return this.paginationComponent.pages.push({
+      selected: false,
+      page_number: number,
+    });
+  }
+
+  skipEllipsis(pageNumber: number): number {
+    if (pageNumber === 1) return pageNumber - 1;
+    else if (pageNumber === this.paginationComponent.pages.length - 2)
+      return pageNumber + 1;
+    else return pageNumber;
+  }
+
+  hidePageNumber(pageNumber: number): boolean {
+    return (
+      (pageNumber <
+        this.paginationComponent.currentPageNumber -
+          this.paginationComponent.previousNextQuantity ||
+        pageNumber >
+          this.paginationComponent.currentPageNumber +
+            this.paginationComponent.previousNextQuantity) &&
+      pageNumber !== this.paginationComponent.totalPages() &&
+      pageNumber !== 1 &&
+      pageNumber !== -1 &&
+      pageNumber !== 0
+    );
+  }
+
+  isLimit(pageNumber: number): Limit {
+    const leftLimit =
+      this.paginationComponent.currentPageNumber -
+      this.paginationComponent.previousNextQuantity;
+    const showLeftEllipsis =
+      this.paginationComponent.currentPageNumber - 1 >
+      this.paginationComponent.previousNextQuantity + 1;
+    const firstPages =
+      this.paginationComponent.currentPageNumber < 5 && pageNumber <= 5;
+
+    return {
+      leftLimit: leftLimit,
+      showLeftEllipsis: showLeftEllipsis,
+      firstPages: firstPages,
+    };
+  }
+
+  shouldShowPageNumber(pageNumber: number, limitFunction: Limit): boolean {
+    if (
+      limitFunction.firstPages ||
+      pageNumber === this.paginationComponent.totalPages()
+    ) {
+      return false;
+    }
+    if (this.withinEndRange()) {
+      return this.isPageNearEnd(pageNumber, limitFunction);
+    }
+    return this.hidePageNumber(pageNumber);
+  }
+
+  ellipsisInPagination(pageNumber: number): boolean {
+    const limitFunction = this.isLimit(pageNumber);
+    if (this.paginationComponent.totalPages() <= 9) {
+      return false;
+    }
+    if (pageNumber === -1) {
+      return !limitFunction.showLeftEllipsis;
+    }
+    return this.shouldShowPageNumber(pageNumber, limitFunction);
+  }
+
+  withinEndRange(): boolean {
+    return (
+      this.paginationComponent.currentPageNumber >=
+      this.paginationComponent.totalPages() - 3
+    );
+  }
+
+  isPageNearEnd(pageNumber: number, limitFunction: Limit): boolean {
+    if (this.withinEndRange()) {
+      const isLast =
+        pageNumber === 1 ||
+        pageNumber >= this.paginationComponent.totalPages() - 4;
+      const beyondPages = pageNumber >= limitFunction.leftLimit;
+      return !isLast && !beyondPages;
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
fix #512 

## Description 

When the number of numeric buttons is greater than or equal to 10, the advanced pattern is displayed and when clicking on the ellipsis, the selection must be returned or advanced to 5 numbers, when it is less than or equal to 9, the simple pattern is displayed.

## Screenshots
Simple Pattern 
![SimplePattern](https://user-images.githubusercontent.com/103749046/231482873-e2d3fa83-52a4-4118-80fe-5807fc7dee69.png)
Advanced Standard 
![ShowPages](https://user-images.githubusercontent.com/103749046/231483076-979aaee4-0890-4d48-94a0-9bba16a43ddb.png)
When hover on the ellipsis 
![Captura de tela de 2023-04-06 08-44-38](https://user-images.githubusercontent.com/103749046/231483288-59a8abba-f7b8-4bf1-a227-678788b8cf2c.png)
When the ellipsis is clicked and the next 5 numbers are displayed
![EllipsisLeft](https://user-images.githubusercontent.com/103749046/231483621-6c961f29-9e7f-491d-8691-88d7bb32af24.png)
