### PR TITLE
feat: add type danger to table action and popconfirm dynamic description

### DIFF
--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -99,12 +99,19 @@
               *ngIf="action.confirm"
               ionPopConfirm
               [ionPopConfirmTitle]="action.confirm.title"
-              [ionPopConfirmDesc]="action.confirm.description"
+              [ionPopConfirmDesc]="
+                !!action.confirm.description
+                  ? action.confirm.description
+                  : !!action.confirm.dynamicDescription
+                  ? action.confirm.dynamicDescription(row)
+                  : undefined
+              "
               (ionOnConfirm)="handleEvent(row, action)"
               [title]="action.label"
               [attr.data-testid]="'row-' + index + '-' + action.label"
               type="ghost"
               size="sm"
+              [danger]="!!action.danger"
               [iconType]="action.icon"
               [circularButton]="true"
               [disabled]="action.show ? !showAction(row, action) : false"
@@ -116,6 +123,7 @@
               [attr.data-testid]="'row-' + index + '-' + action.label"
               type="ghost"
               size="sm"
+              [danger]="!!action.danger"
               [iconType]="action.icon"
               [circularButton]="true"
               (ionOnClick)="handleEvent(row, action)"

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -1,15 +1,15 @@
-import { fireEvent, render, screen } from '@testing-library/angular';
+import { fireEvent, render, screen, within } from '@testing-library/angular';
+import { IonButtonModule } from '../button/button.module';
+import { IonCheckboxModule } from '../checkbox/checkbox.module';
+import { IonSmartTableProps } from '../core/types';
+import { IonIconModule } from '../icon/icon.module';
+import { IonPaginationModule } from '../pagination/pagination.module';
+import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
+import { ActionTable, Column, EventTable } from '../table/utilsTable';
+import { IonTagModule } from '../tag/tag.module';
+import { PipesModule } from '../utils/pipes/pipes.module';
 import { SafeAny } from '../utils/safe-any';
 import { IonSmartTableComponent } from './smart-table.component';
-import { ActionTable, Column, EventTable } from '../table/utilsTable';
-import { IonCheckboxModule } from '../checkbox/checkbox.module';
-import { IonPaginationModule } from '../pagination/pagination.module';
-import { IonTagModule } from '../tag/tag.module';
-import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
-import { IonButtonModule } from '../button/button.module';
-import { IonIconModule } from '../icon/icon.module';
-import { IonSmartTableProps } from '../core/types';
-import { PipesModule } from '../utils/pipes/pipes.module';
 
 const disabledArrowColor = '#CED2DB';
 const enabledArrowColor = '#0858CE';
@@ -233,6 +233,25 @@ describe('Table > Actions', () => {
   it.each(actions)('should render icon action', async ({ icon }) => {
     await sut(tableWithActions);
     expect(document.getElementById(`ion-icon-${icon}`)).toBeInTheDocument();
+  });
+
+  it('should render action with danger class when action has danger config', async () => {
+    const tableItemDeleted = {
+      ...tableWithActions,
+      config: {
+        ...tableWithActions.config,
+        actions: [
+          {
+            ...actions[0],
+            danger: true,
+          },
+        ],
+      },
+    } as IonSmartTableProps<Character>;
+    await sut(tableItemDeleted);
+    const rowAction = screen.getByTestId(`row-0-${actions[0].label}`);
+    expect(rowAction).toHaveAttribute('ng-reflect-danger', 'true');
+    expect(within(rowAction).getByRole('button')).toHaveClass('danger');
   });
 
   it('should not render popconfirm when action dont has confirm config', async () => {
@@ -589,7 +608,7 @@ describe('Table > Pagination', () => {
 });
 
 describe('Table > Action with confirm', () => {
-  it('should render popconfirm in action', async () => {
+  it('should render popconfirm with title in action', async () => {
     const withPopconfirm = JSON.parse(
       JSON.stringify(defaultProps)
     ) as IonSmartTableProps<Character>;
@@ -614,7 +633,7 @@ describe('Table > Action with confirm', () => {
     );
   });
 
-  it('should render popconfirm in action', async () => {
+  it('should render popconfirm with title and description in action', async () => {
     const withPopconfirm = JSON.parse(
       JSON.stringify(defaultProps)
     ) as IonSmartTableProps<Character>;
@@ -636,6 +655,31 @@ describe('Table > Action with confirm', () => {
     expect(actionBtn).toHaveAttribute(
       'ng-reflect-ion-pop-confirm-desc',
       actionConfig.confirm.description
+    );
+  });
+
+  it('should render popconfirm description with data provided from row', async () => {
+    const withPopconfirm = JSON.parse(
+      JSON.stringify(defaultProps)
+    ) as IonSmartTableProps<Character>;
+    withPopconfirm.events = { emit: jest.fn() } as SafeAny;
+    const dynamicDescription = jest.fn().mockReturnValue('dynamic description');
+
+    const actionConfig = {
+      label: 'Excluir',
+      icon: 'trash',
+      confirm: {
+        title: 'Você tem certeza?',
+        dynamicDescription,
+      },
+    };
+    withPopconfirm.config.actions = [actionConfig];
+
+    await sut(withPopconfirm);
+
+    expect(dynamicDescription).toHaveBeenCalled();
+    expect(dynamicDescription).toHaveBeenCalledWith(
+      defaultProps.config.data[0]
     );
   });
 });

--- a/projects/ion/src/lib/table/table.component.html
+++ b/projects/ion/src/lib/table/table.component.html
@@ -87,12 +87,19 @@
               *ngIf="action.confirm"
               ionPopConfirm
               [ionPopConfirmTitle]="action.confirm.title"
-              [ionPopConfirmDesc]="action.confirm.description"
+              [ionPopConfirmDesc]="
+                !!action.confirm.description
+                  ? action.confirm.description
+                  : !!action.confirm.dynamicDescription
+                  ? action.confirm.dynamicDescription(row)
+                  : undefined
+              "
               (ionOnConfirm)="handleEvent(row, action)"
               [title]="action.label"
               [attr.data-testid]="'row-' + index + '-' + action.label"
               type="ghost"
               size="sm"
+              [danger]="!!action.danger"
               [iconType]="action.icon"
               [circularButton]="true"
               [disabled]="action.show ? !showAction(row, action) : false"
@@ -104,6 +111,7 @@
               [attr.data-testid]="'row-' + index + '-' + action.label"
               type="ghost"
               size="sm"
+              [danger]="!!action.danger"
               [iconType]="action.icon"
               [circularButton]="true"
               (ionOnClick)="handleEvent(row, action)"

--- a/projects/ion/src/lib/table/table.component.spec.ts
+++ b/projects/ion/src/lib/table/table.component.spec.ts
@@ -1,5 +1,5 @@
 import { FormsModule } from '@angular/forms';
-import { fireEvent, render, screen } from '@testing-library/angular';
+import { fireEvent, render, screen, within } from '@testing-library/angular';
 import { IonButtonModule } from '../button/button.module';
 import { IonCheckboxModule } from '../checkbox/checkbox.module';
 import { IonTableProps } from '../core/types';
@@ -186,6 +186,25 @@ describe('Table > Actions', () => {
   it.each(actions)('should render icon action', async ({ icon }) => {
     await sut(tableWithActions);
     expect(document.getElementById(`ion-icon-${icon}`)).toBeInTheDocument();
+  });
+
+  it('should render action with danger class when action has danger config', async () => {
+    const tableItemDeleted = {
+      ...tableWithActions,
+      config: {
+        ...tableWithActions.config,
+        actions: [
+          {
+            ...actions[0],
+            danger: true,
+          },
+        ],
+      },
+    } as IonTableProps<Disco>;
+    await sut(tableItemDeleted);
+    const rowAction = screen.getByTestId(`row-0-${actions[0].label}`);
+    expect(rowAction).toHaveAttribute('ng-reflect-danger', 'true');
+    expect(within(rowAction).getByRole('button')).toHaveClass('danger');
   });
 
   it('should render trash button disabled when the item is deleted', async () => {
@@ -540,7 +559,7 @@ describe('Table > Pagination', () => {
 });
 
 describe('Table > Action with confirm', () => {
-  it('should render popconfirm in action', async () => {
+  it('should render popconfirm with title in action', async () => {
     const withPopconfirm = JSON.parse(
       JSON.stringify(defaultProps)
     ) as IonTableProps<Disco>;
@@ -564,7 +583,7 @@ describe('Table > Action with confirm', () => {
     );
   });
 
-  it('should render popconfirm in action', async () => {
+  it('should render popconfirm with title and description in action', async () => {
     const withPopconfirm = JSON.parse(
       JSON.stringify(defaultProps)
     ) as IonTableProps<Disco>;
@@ -585,6 +604,31 @@ describe('Table > Action with confirm', () => {
     expect(actionBtn).toHaveAttribute(
       'ng-reflect-ion-pop-confirm-desc',
       actionConfig.confirm.description
+    );
+  });
+
+  it('should render popconfirm description with data provided from row', async () => {
+    const withPopconfirm = JSON.parse(
+      JSON.stringify(defaultProps)
+    ) as IonTableProps<Disco>;
+    withPopconfirm.events = { emit: jest.fn() } as SafeAny;
+    const dynamicDescription = jest.fn().mockReturnValue('dynamic description');
+
+    const actionConfig = {
+      label: 'Excluir',
+      icon: 'trash',
+      confirm: {
+        title: 'Você tem certeza?',
+        dynamicDescription,
+      },
+    };
+    withPopconfirm.config.actions = [actionConfig];
+
+    await sut(withPopconfirm);
+
+    expect(dynamicDescription).toHaveBeenCalled();
+    expect(dynamicDescription).toHaveBeenCalledWith(
+      defaultProps.config.data[0]
     );
   });
 });

--- a/projects/ion/src/lib/table/utilsTable.ts
+++ b/projects/ion/src/lib/table/utilsTable.ts
@@ -1,5 +1,5 @@
-import { SafeAny } from '../utils/safe-any';
 import { ConfigSmartTable } from '../core/types';
+import { SafeAny } from '../utils/safe-any';
 
 export enum EventTable {
   SORT = 'sort',
@@ -31,11 +31,13 @@ export interface Column {
 export interface ActionConfirm {
   title: string;
   description?: string;
+  dynamicDescription?: (row: SafeAny) => string;
 }
 
 export interface ActionTable {
   label: string;
   icon: string;
+  danger?: boolean;
   show?: (row: SafeAny) => boolean;
   call?: (row: SafeAny) => void;
   confirm?: ActionConfirm;

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -1,8 +1,8 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, Story } from '@storybook/angular';
-import { IonSmartTableModule } from '../projects/ion/src/public-api';
 import { IonSmartTableComponent } from '../projects/ion/src/lib/smart-table/smart-table.component';
 import { SafeAny } from '../projects/ion/src/lib/utils/safe-any';
+import { IonSmartTableModule } from '../projects/ion/src/public-api';
 
 export default {
   title: 'Ion/Data Display/SmartTable',
@@ -113,3 +113,30 @@ SortWithDebounce.args = returnTableConfig(data, columns, actions, 2, 2000);
 
 export const LargePagination = Template.bind({});
 LargePagination.args = returnTableConfig(data, columns, actions, 2000);
+
+export const ActionWithDanger = Template.bind({});
+ActionWithDanger.args = returnTableConfig(
+  data,
+  columns,
+  [{ ...actions[0], danger: true }],
+  2
+);
+
+export const PopConfirmDynamicDescription = Template.bind({});
+PopConfirmDynamicDescription.args = returnTableConfig(
+  data,
+  columns,
+  [
+    {
+      ...actions[0],
+      confirm: {
+        ...actions[0].confirm,
+        description: undefined,
+        dynamicDescription: (row: SafeAny): string => {
+          return `Você estará excluindo o disco ${row.name} da sua base de dados!`;
+        },
+      },
+    },
+  ],
+  2
+);

--- a/stories/Table.stories.ts
+++ b/stories/Table.stories.ts
@@ -253,3 +253,34 @@ CustomItemsPerPage.args = {
     },
   },
 };
+
+export const ActionWithDanger = Template.bind({});
+ActionWithDanger.args = {
+  config: {
+    data,
+    columns,
+    actions: [{ ...actions[0], danger: true }],
+    pagination: { total: 2, itemsPerPage: 2 },
+  },
+};
+
+export const PopConfirmDynamicDescription = Template.bind({});
+PopConfirmDynamicDescription.args = {
+  config: {
+    data,
+    columns,
+    actions: [
+      {
+        ...actions[0],
+        confirm: {
+          ...actions[0].confirm,
+          description: undefined,
+          dynamicDescription: (row: SafeAny): string => {
+            return `Você estará excluindo o disco ${row.name} da sua base de dados!`;
+          },
+        },
+      },
+    ],
+    pagination: { total: 2, itemsPerPage: 2 },
+  },
+};


### PR DESCRIPTION
## Issue Number

fix #612 

## Description
Add danger boolean to actions so it can render button as danger type:
![image](https://user-images.githubusercontent.com/57760325/232860418-da3a1272-8c92-4a55-96f1-b379dbc00ee2.png)

Add dynamic description to popconfirm, so we can access row data and customize description:
![image](https://user-images.githubusercontent.com/57760325/232860650-b3434f0c-b391-4385-bf15-4cb79fab706c.png)

Storybook: https://62eab350a45bdb0a5818520e-exucuzowes.chromatic.com/