### PR TITLE
fix: icon color when a ghost danger button is disabled

### DIFF
--- a/projects/ion/src/lib/button/button.component.scss
+++ b/projects/ion/src/lib/button/button.component.scss
@@ -66,7 +66,7 @@ button {
 
     ion-icon {
       ::ng-deep svg {
-        fill: $neutral-5;
+        fill: $neutral-5 !important;
       }
     }
   }

--- a/stories/Button.stories.mdx
+++ b/stories/Button.stories.mdx
@@ -447,6 +447,18 @@ E 6 outras propriedades adicionais.
     }}
   </Story>
   <Story
+    name="disabled in ghost danger icon button"
+    decorators={[
+      moduleMetadata({
+        imports: [CommonModule, IonSharedModule],
+      }),
+    ]}
+  >
+    {{
+      template: `<ion-button label="Ghost" type="ghost" [danger]="true" iconType="close" [disabled]=false></ion-button>`,
+    }}
+  </Story>
+  <Story
     name="disabled in dashed button"
     decorators={[
       moduleMetadata({

--- a/stories/Button.stories.mdx
+++ b/stories/Button.stories.mdx
@@ -455,7 +455,7 @@ E 6 outras propriedades adicionais.
     ]}
   >
     {{
-      template: `<ion-button label="Ghost" type="ghost" [danger]="true" iconType="close" [disabled]=false></ion-button>`,
+      template: `<ion-button label="Ghost" type="ghost" [danger]="true" iconType="close" [disabled]=true></ion-button>`,
     }}
   </Story>
   <Story


### PR DESCRIPTION
## Issue Number

fix #623 

## Description

The danger class was overwriting the disabled, so I added important to the fill property.

## Proposed Changes

- added a new story to reproduce the error;
- added important to the fill on the ion-icon selector.

## How to Test

Check story "disabled in ghost danger icon button" on the storybook.

## Screenshots

![image](https://user-images.githubusercontent.com/98463818/235212502-2368891a-873d-4fa8-aa62-c55f7fbd347e.png)

## View Storybook

[Storybook Link](https://62eab350a45bdb0a5818520e-gcljhmkqet.chromatic.com/?path=/story/ion-navigation-button--disabled-in-ghost-danger-icon-button)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.
