### PR TITLE
fix: arrow colors on the breadcrumb component

### DIFF
--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.scss
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.scss
@@ -20,7 +20,7 @@
 
   ion-icon {
     ::ng-deep svg {
-      fill: $neutral-6;
+      fill: $neutral-5;
     }
   }
 }


### PR DESCRIPTION
## Issue Number

fix #562 

## Description

The color of the arrows on the breadcrumb component were $neutral6 when should be $neutral5, so I changed the fill property to the right variable.

## Proposed Changes

- changed the color of the fill property.
- 
## How to Test

Check the story of the breadcrumb.

## Screenshots

![image](https://user-images.githubusercontent.com/98463818/235222987-5029ebd4-2494-4d66-b959-8b17a1d20a92.png)

## View Storybook

Provide a link to the chromatic Storybook that shows the proposed changes so reviewers can easily see the changes in action.

Please also be aware that in addition to the Chromatic link, the link in the pull request description will also need to be updated whenever changes are made.

<details>
  <summary>How can I access the Chromatic link?</summary>

- Open the pull request that you wish to verify the Storybook Chromatic on.

- At the bottom of the "Checks" comment, click on "Details" next to the "Chromatic/chromatic-deployment" status.

- On the "Checks" page, you will see a list of checks. Select the "Publish to Chromatic" section.

- Scroll down until you find the section "View your Storybook at https://examplelink", that represents the desired link.

</details>

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.