### PR TITLE
feat: button icon change to left arrows when the sidebar is compressed

### DIFF
--- a/projects/ion/src/lib/pagination/pagination.component.spec.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.spec.ts
@@ -132,7 +132,6 @@ describe('Pagination > Page sizes', () => {
             name: /10 \/ página/i,
           })
         );
-        screen.logTestingPlaygroundURL();
         const view = screen.getByTestId('ion-dropdown');
         expect(within(view).getByText(`${label} / página`)).toBeVisible();
       }

--- a/projects/ion/src/lib/sidebar/sidebar.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar.component.html
@@ -10,10 +10,14 @@
       [src]="logo"
       alt="logo"
     />
-    <ng-template
+    <ion-button
       *ngIf="!closed"
-      [ngTemplateOutlet]="btnToggleVisibility"
-    ></ng-template>
+      data-testid="ion-sidebar__toggle-visibility"
+      iconType="left3"
+      size="lg"
+      type="ghost"
+      (ionOnClick)="toggleVisibility()"
+    ></ion-button>
   </header>
   <section class="ion-sidebar__items">
     <ng-container *ngFor="let item of items; let i = index">
@@ -44,10 +48,6 @@
 </nav>
 
 <span>
-  <ng-template *ngTemplateOutlet="btnToggleVisibility"></ng-template>
-</span>
-
-<ng-template #btnToggleVisibility>
   <ion-button
     data-testid="ion-sidebar__toggle-visibility"
     iconType="sandwich"
@@ -55,4 +55,4 @@
     type="ghost"
     (ionOnClick)="toggleVisibility()"
   ></ion-button>
-</ng-template>
+</span>


### PR DESCRIPTION
## Issue Number

fix #566 

## Description

The buttons that changes the visibility of the sidebar was always of the type sandwich, so I changed the buttons from ng-templates to the ion-button component changing the type of one to the left3.

## Proposed Changes

- removed the ng-templates;
- added two ion-button components with different types.

## How to Test

Check the story "Sidebar > Default" on the storybook

## Screenshots

![image](https://user-images.githubusercontent.com/98463818/236283284-ea409b4c-aeba-4a4d-8f77-25592ceac778.png)

## View Storybook

Provide a link to the chromatic Storybook that shows the proposed changes so reviewers can easily see the changes in action.

Please also be aware that in addition to the Chromatic link, the link in the pull request description will also need to be updated whenever changes are made.

<details>
  <summary>How can I access the Chromatic link?</summary>

- Open the pull request that you wish to verify the Storybook Chromatic on.

- At the bottom of the "Checks" comment, click on "Details" next to the "Chromatic/chromatic-deployment" status.

- On the "Checks" page, you will see a list of checks. Select the "Publish to Chromatic" section.

- Scroll down until you find the section "View your Storybook at https://examplelink", that represents the desired link.

</details>

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.