### PR TITLE
fix: border, background and text colors adjusted on the chip(selected state) component

### DIFF
--- a/projects/ion/src/lib/chip/chip.component.scss
+++ b/projects/ion/src/lib/chip/chip.component.scss
@@ -69,7 +69,7 @@
   font-family: 'Source Sans Pro', sans-serif;
   font-style: normal;
   cursor: pointer;
-  @include add-colors($primary-2, $primary-color);
+  @include add-colors($primary-1, $primary-color);
   @include icon-color($primary-color);
 
   &:hover {
@@ -87,10 +87,10 @@
   }
 
   &:active {
-    border: 1.5px solid $primary-5;
+    border: 1.5px solid $primary-7;
     outline: none;
-    @include add-colors($primary-2, $primary-5);
-    @include icon-color($primary-5);
+    @include add-colors($primary-3, $primary-7);
+    @include icon-color($primary-7);
   }
 
   &:disabled {


### PR DESCRIPTION
## Issue Number

fix #563 

## Description

The colors of the border, text and background in the default and press events of the selected state were wrong, so I changed to the right colors on the selectors in the scss file.

## Proposed Changes

- Changed the colors of the border, background and text in the default and press events.

## How to Test

Check the Navigation > Chips > Selected story of the storybook

## Screenshots

![image](https://user-images.githubusercontent.com/98463818/236549290-48f58ba2-6c8e-4af2-9847-381c7fd94dad.png)

![ezgif-5-9f6f5885e6](https://user-images.githubusercontent.com/98463818/236549848-c75bb8f9-552b-4fa7-9dc6-a485a89b2a87.gif)

## View Storybook

[Storybook Link](https://62eab350a45bdb0a5818520e-gwrvnbntjt.chromatic.com/?path=/story/ion-navigation-chips--selected)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.