### PR TITLE
fix: disable event emitter when table is loading

### DIFF
--- a/projects/ion/src/lib/pagination/pagination.component.html
+++ b/projects/ion/src/lib/pagination/pagination.component.html
@@ -24,8 +24,9 @@
       [class]="'square-pag ' + 'page-' + size"
       [class.selected]="page.selected"
       [attr.data-testid]="'page-' + page.page_number"
-      (click)="!loading && selectPage(page.page_number)"
+      (click)="selectPage(page.page_number)"
       [class.disabled]="loading"
+      [disabled]="loading"
     >
       <span>{{ page.page_number }}</span>
     </button>

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -69,7 +69,7 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   }
 
   selectPage(pageNumber = 1, emitEvent = true): void {
-    if (this.pages) {
+    if (this.pages && !this.loading) {
       this.pages.forEach((pageEach) => {
         pageEach.selected = false;
       });
@@ -99,13 +99,13 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   }
 
   previous(): void {
-    if (!this.inFirstPage()) {
+    if (!this.inFirstPage() && !this.loading) {
       this.selectPage(this.currentPage().page_number - 1);
     }
   }
 
   next(): void {
-    if (!this.inLastPage()) {
+    if (!this.inLastPage() && !this.loading) {
       this.selectPage(this.currentPage().page_number + 1);
     }
   }


### PR DESCRIPTION
## Issue Number

In the pagination component, while it is disabled, it is possible to click multiple times and the pagination will advance, even though the button appears disabled.
