### PR TITLE
640 fix ion smart table

### DIFF
--- a/projects/ion/src/lib/pagination/pagination.component.html
+++ b/projects/ion/src/lib/pagination/pagination.component.html
@@ -1,5 +1,6 @@
 <div class="pag-container">
   <ion-button
+    data-testid="itemsPerPage"
     rightSideIcon="true"
     *ngIf="allowChangeQtdItems"
     [label]="labelPerPage"
@@ -7,6 +8,7 @@
     customId="btn-select"
     (selected)="changeItemsPerPage($event)"
     type="secondary"
+    [disabled]="loading"
   ></ion-button>
 
   <ion-button

--- a/projects/ion/src/lib/pagination/pagination.component.spec.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.spec.ts
@@ -119,7 +119,7 @@ describe('Pagination > Page sizes', () => {
     );
 
     it.each(LOADING_STATUS)(
-      'should show items per page disabled when loading is %b',
+      'should show items per page disabled as %b when loading is %b',
       async (loadingValue) => {
         await sut({
           ...defaultComponent,
@@ -197,47 +197,4 @@ describe('Pagination > Events', () => {
     });
     expect(screen.queryAllByText('20 / página')).toHaveLength(1);
   });
-
-  const NUMBER_BUTTONS = [20, 30, 40, 46];
-
-  it.each(NUMBER_BUTTONS)(
-    'should not display any button of testID equal to $n after clicking itemsPerPage when loading is true',
-    async (numberButton) => {
-      await sut({
-        loading: true,
-        total: 46,
-        allowChangeQtdItems: true,
-      });
-      const label = '10 / página';
-      const changeItemsPerPageElement = screen.getByTestId(`btn-${label}`);
-      fireEvent.click(changeItemsPerPageElement);
-
-      const button20PerPage = screen.queryByTestId(
-        `btn-${numberButton} / página`
-      );
-      expect(button20PerPage).not.toBeInTheDocument();
-    }
-  );
-
-  it.each(NUMBER_BUTTONS)(
-    'Should change the button with testId 10 for the button with testId %n when loading is false.',
-    async (numberButton) => {
-      await sut({
-        loading: false,
-        total: 46,
-        allowChangeQtdItems: true,
-      });
-      const btn10TestId = 'btn-10 / página';
-      const changeItemsPerPageElement = screen.getByTestId(btn10TestId);
-      fireEvent.click(changeItemsPerPageElement);
-      const dropdownItem = screen.getByText(`${numberButton} / página`);
-      fireEvent.click(dropdownItem);
-      const btnPerPageClicked = screen.getByTestId(
-        `btn-${numberButton} / página`
-      );
-      expect(btnPerPageClicked).toBeInTheDocument();
-      const btn10PerPage = screen.queryByTestId(btn10TestId);
-      expect(btn10PerPage).not.toBeInTheDocument();
-    }
-  );
 });

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -36,9 +36,11 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   pages: Page[] = [];
 
   changeItemsPerPage(itemsSelected: DropdownItem[]): void {
-    this.itemsPerPage = Number(itemsSelected[0].label.split(' / página')[0]);
-    this.remountPages();
-    this.labelPerPage = this.getSelectedItemsPerPageLabel(this.optionsPage);
+    if (!this.loading) {
+      this.itemsPerPage = Number(itemsSelected[0].label.split(' / página')[0]);
+      this.remountPages();
+      this.labelPerPage = this.getSelectedItemsPerPageLabel(this.optionsPage);
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ion/src/lib/select/select.component.scss
+++ b/projects/ion/src/lib/select/select.component.scss
@@ -12,8 +12,9 @@
 
 .ion-select__container-input {
   ::ng-deep div.input-container {
-    .input{
-      input, ion-icon {
+    .input {
+      input,
+      ion-icon {
         cursor: pointer;
       }
     }

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -147,9 +147,15 @@
     class="footer-table"
   >
     <div class="total-container">
-      <span>Total: {{ config.pagination.total }}</span>
-      <span *ngIf="config.loading" data-testid="loading-pagination">
-        Carregando página..
+      <span *ngIf="!config.loading" data-testid="total-pagination"
+        >Total: {{ config.pagination.total }}</span
+      >
+      <span
+        *ngIf="config.loading"
+        data-testid="loading-pagination"
+        class="loading-message"
+      >
+        Carregando página
       </span>
     </div>
 

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -600,10 +600,12 @@ describe('Table > Pagination', () => {
     const tableWithLoading = JSON.parse(
       JSON.stringify(defaultProps)
     ) as IonSmartTableProps<Character>;
+    const totalPagination = screen.getByTestId('total-pagination');
     tableWithLoading.config.loading = true;
 
     await sut(tableWithLoading);
     expect(screen.getByTestId('loading-pagination')).toBeInTheDocument();
+    expect(totalPagination).not.toBeInTheDocument();
   });
 });
 

--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -2,6 +2,24 @@
 
 $radius: 8px;
 
+@keyframes dot-animation {
+  0% {
+    content: '.  ';
+  }
+  25% {
+    content: '.. ';
+  }
+  50% {
+    content: '...';
+  }
+  75% {
+    content: '.. ';
+  }
+  100% {
+    content: '.  ';
+  }
+}
+
 .ion-table {
   border-radius: $radius;
 }
@@ -157,6 +175,11 @@ table {
   font-size: 14px;
   line-height: 20px;
   color: $neutral-7;
+
+  .loading-message:after {
+    content: '...';
+    animation: dot-animation 1.5s infinite;
+  }
 
   .pagination {
     max-width: 80%;


### PR DESCRIPTION
## [fix #640](https://github.com/Brisanet/ion/issues/640)

## Description

Fixed the issue where when the table was loading it was possible to change the number of pages while it shouldn't be possible.
Feat animation of ion-smart-table when table status is loading

## Proposed Changes

- When the table is loading it will not be possible to change the number of items per page
- Create animated of ion-smart-table pagination when table status is loading

## How to Test

When clicking to page through the ion-smart-table table using a SLOW 3G network, you should not be able to change the number of items per page

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.

## Screenshots


https://github.com/Brisanet/ion/assets/54484070/15a35c71-60ea-4ae6-be48-ba2e7ad24427


