### PR TITLE
fix: fixing issue where popconfirm opened more than one

### DIFF
--- a/projects/ion/src/lib/popconfirm/popconfirm.directive.spec.ts
+++ b/projects/ion/src/lib/popconfirm/popconfirm.directive.spec.ts
@@ -176,10 +176,11 @@ describe('Directive: Popconfirm', () => {
     expect(screen.queryByTestId('pop-confirm-btn')).not.toBeInTheDocument();
   });
 
-  it('should not open new popconfirm when be opened', () => {
-    directive.open();
+  it('should close popconfirm if it is already open', () => {
     directive.open();
     expect(screen.queryAllByTestId('pop-confirm-btn')).toHaveLength(1);
+    directive.open();
+    expect(screen.queryAllByTestId('pop-confirm-btn')).toHaveLength(0);
   });
 });
 
@@ -317,7 +318,7 @@ describe('Popconfirm position when it opens', () => {
   });
 
   it('should set the correct position', () => {
-    const popconfirmElement = screen.getAllByTestId('sup-container')[2];
+    const popconfirmElement = screen.getAllByTestId('sup-container')[0];
     const position: PopOffset = directive.setPosition(
       popconfirmElement,
       documentWidth,

--- a/projects/ion/src/lib/popconfirm/popconfirm.directive.spec.ts
+++ b/projects/ion/src/lib/popconfirm/popconfirm.directive.spec.ts
@@ -176,11 +176,10 @@ describe('Directive: Popconfirm', () => {
     expect(screen.queryByTestId('pop-confirm-btn')).not.toBeInTheDocument();
   });
 
-  it('should close popconfirm if it is already open', () => {
+  it('should not open new popconfirm when be opened', () => {
+    directive.open();
     directive.open();
     expect(screen.queryAllByTestId('pop-confirm-btn')).toHaveLength(1);
-    directive.open();
-    expect(screen.queryAllByTestId('pop-confirm-btn')).toHaveLength(0);
   });
 });
 

--- a/projects/ion/src/lib/popconfirm/popconfirm.directive.ts
+++ b/projects/ion/src/lib/popconfirm/popconfirm.directive.ts
@@ -51,36 +51,11 @@ export class IonPopConfirmDirective {
 
   open(): void {
     if (this.IonPopConfirmComponentRef) {
+      this.closePopConfirm();
       return;
     }
-    const popover = this.componentFactoryResolver
-      .resolveComponentFactory(IonPopConfirmComponent)
-      .create(this.injector);
-
-    this.IonPopConfirmComponentRef = popover;
-
-    this.appRef.attachView(this.IonPopConfirmComponentRef.hostView);
-    this.IonPopConfirmComponentRef.changeDetectorRef.detectChanges();
-
-    const popconfirmElement = this.IonPopConfirmComponentRef.location
-      .nativeElement as HTMLElement;
-
-    this.document.body.appendChild(popconfirmElement);
-
-    this.IonPopConfirmComponentRef.instance.ionPopConfirmTitle =
-      this.ionPopConfirmTitle;
-
-    this.IonPopConfirmComponentRef.instance.ionPopConfirmDesc =
-      this.ionPopConfirmDesc;
-
-    this.IonPopConfirmComponentRef.instance.ionPopConfirmType =
-      this.ionPopConfirmType;
-
-    this.IonPopConfirmComponentRef.instance.ionOnConfirm.subscribe(() => {
-      this.closePopConfirm();
-      this.ionOnConfirm.emit();
-    });
-
+    this.closeAllPopsConfirm();
+    this.createPopConfirm();
     this.IonPopConfirmComponentRef.instance.ionOnClose.subscribe(() => {
       this.closePopConfirm();
       this.ionOnClose.emit();
@@ -119,6 +94,45 @@ export class IonPopConfirmDirective {
     };
 
     return offset;
+  }
+
+  closeAllPopsConfirm() {
+    const existingPopConfirms = document.querySelectorAll('ion-popconfirm');
+    if (existingPopConfirms) {
+      existingPopConfirms.forEach((popConfirm) => {
+        popConfirm.remove();
+      });
+    }
+  }
+
+  createPopConfirm() {
+    const popover = this.componentFactoryResolver
+      .resolveComponentFactory(IonPopConfirmComponent)
+      .create(this.injector);
+
+    this.IonPopConfirmComponentRef = popover;
+
+    this.appRef.attachView(this.IonPopConfirmComponentRef.hostView);
+    this.IonPopConfirmComponentRef.changeDetectorRef.detectChanges();
+
+    const popconfirmElement = this.IonPopConfirmComponentRef.location
+      .nativeElement as HTMLElement;
+
+    this.document.body.appendChild(popconfirmElement);
+
+    this.IonPopConfirmComponentRef.instance.ionPopConfirmTitle =
+      this.ionPopConfirmTitle;
+
+    this.IonPopConfirmComponentRef.instance.ionPopConfirmDesc =
+      this.ionPopConfirmDesc;
+
+    this.IonPopConfirmComponentRef.instance.ionPopConfirmType =
+      this.ionPopConfirmType;
+
+    this.IonPopConfirmComponentRef.instance.ionOnConfirm.subscribe(() => {
+      this.closePopConfirm();
+      this.ionOnConfirm.emit();
+    });
   }
 
   setStyle(element: HTMLElement, offset: PopOffset): void {

--- a/projects/ion/src/lib/popconfirm/popconfirm.directive.ts
+++ b/projects/ion/src/lib/popconfirm/popconfirm.directive.ts
@@ -50,10 +50,6 @@ export class IonPopConfirmDirective {
   ) {}
 
   open(): void {
-    if (this.IonPopConfirmComponentRef) {
-      this.closePopConfirm();
-      return;
-    }
     this.closeAllPopsConfirm();
     this.createPopConfirm();
     this.IonPopConfirmComponentRef.instance.ionOnClose.subscribe(() => {
@@ -96,7 +92,7 @@ export class IonPopConfirmDirective {
     return offset;
   }
 
-  closeAllPopsConfirm() {
+  closeAllPopsConfirm(): void {
     const existingPopConfirms = document.querySelectorAll('ion-popconfirm');
     if (existingPopConfirms) {
       existingPopConfirms.forEach((popConfirm) => {
@@ -105,7 +101,7 @@ export class IonPopConfirmDirective {
     }
   }
 
-  createPopConfirm() {
+  createPopConfirm(): void {
     const popover = this.componentFactoryResolver
       .resolveComponentFactory(IonPopConfirmComponent)
       .create(this.injector);


### PR DESCRIPTION
fix #644 

## Description

This PR changes the behavior of popconfirm, because the way it is currently it is possible to open numerous popsconfirms making it a mess, and this switch allows only 1 to be shown at a time.

## Proposed Changes

- It is only possible to open a popconfirm

## Screenshots

Before: 

https://github.com/Brisanet/ion/assets/54484070/450f9419-3e77-48a8-8669-23b06ae1fe1e



After:

https://github.com/Brisanet/ion/assets/54484070/22e63478-36c7-4309-84f2-465ee226d330




## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
