### PR TITLE
fix: input-counter correction

### DIFF
--- a/projects/ion/src/lib/input-counter/input-counter.component.html
+++ b/projects/ion/src/lib/input-counter/input-counter.component.html
@@ -7,7 +7,14 @@
     (click)="countDecrement()"
   ></ion-button>
 
-  <input type="number" [(ngModel)]="count" data-testid="input-count" />
+  <input
+    type="text"
+    oninput="this.value = this.value.replace(/[^0-9]/g, '').replace(/(\..*)\./g, '$1');"
+    [(ngModel)]="count"
+    data-testid="input-count"
+    (ngModelChange)="changeCount($event)"
+    [value]="count"
+  />
 
   <ion-button
     data-testid="iconAdd"

--- a/projects/ion/src/lib/input-counter/input-counter.component.spec.ts
+++ b/projects/ion/src/lib/input-counter/input-counter.component.spec.ts
@@ -1,13 +1,21 @@
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { render, fireEvent, screen } from '@testing-library/angular';
+
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+} from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
 import { IonInputCounterComponent } from './input-counter.component';
 import { IonButtonModule } from '../button/button.module';
 
 const sut = async (
   customProps: Partial<IonInputCounterComponent> = {}
-): Promise<void> => {
-  await render(IonInputCounterComponent, {
+): Promise<RenderResult<IonInputCounterComponent>> => {
+  return await render(IonInputCounterComponent, {
     componentProperties: customProps,
     imports: [CommonModule, FormsModule, IonButtonModule],
     declarations: [],
@@ -61,6 +69,15 @@ describe('InputCounter', () => {
       'ng-reflect-size',
       'md'
     );
+  });
+
+  it('should enter non-numeric characters and not affect the value of input-number', async () => {
+    const inputCounter = screen.getByTestId('input-count') as HTMLInputElement;
+    const value = '111';
+    userEvent.type(inputCounter, value);
+    expect(inputCounter.value).toBe(value);
+    userEvent.type(inputCounter, 'abc');
+    expect(inputCounter.value).toBe(value);
   });
 });
 

--- a/projects/ion/src/lib/input-counter/input-counter.component.ts
+++ b/projects/ion/src/lib/input-counter/input-counter.component.ts
@@ -28,4 +28,12 @@ export class IonInputCounterComponent {
     this.count++;
     this.emitEvent();
   }
+
+  public changeCount(count: string): void {
+    const countNumeric = Number(count);
+    if (!isNaN(countNumeric)) {
+      this.count = countNumeric;
+      this.emitEvent();
+    }
+  }
 }


### PR DESCRIPTION
fix #647

## Description

Today it is possible to type the character 'e' in the input-counter, and if the user types a valid number (eg 123), the event is not emitted. This pull request fixes that issue.

## Proposed Changes

- Event emitted when user enters a value
- Characters are not allowed

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
