### PR TITLE
fix: dont emit when click the same page button

### DIFF
--- a/projects/ion/src/lib/pagination/pagination.component.html
+++ b/projects/ion/src/lib/pagination/pagination.component.html
@@ -26,7 +26,7 @@
       [class]="'square-pag ' + 'page-' + size"
       [class.selected]="page.selected"
       [attr.data-testid]="'page-' + page.page_number"
-      (click)="selectPage(page.page_number)"
+      (click)="selectPageOnClick(page.page_number)"
       [class.disabled]="loading"
       [disabled]="loading"
     >

--- a/projects/ion/src/lib/pagination/pagination.component.spec.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.spec.ts
@@ -35,7 +35,7 @@ describe('IonPaginationComponent', () => {
     await sut();
   });
 
-  it.each(['1', '2', '3', '4'])(
+  it.each(['1', '2', '3', '4', '5'])(
     'should render page %s',
     async (page: string) => {
       expect(screen.getByText(page)).toBeInTheDocument();
@@ -168,6 +168,20 @@ describe('Pagination > Events', () => {
     });
     fireEvent.click(screen.getByTestId('page-2'));
     expect(event).toBeCalledTimes(2);
+  });
+
+  it('should not emit an event when the selected page is already selected', async () => {
+    const event = jest.fn();
+    await sut({
+      total: 16,
+      events: {
+        emit: event,
+      } as SafeAny,
+    });
+    event.mockClear();
+    expect(screen.getByTestId('page-1')).toHaveClass('selected');
+    fireEvent.click(screen.getByTestId('page-1'));
+    expect(event).not.toHaveBeenCalled();
   });
 
   it('should show items per page 10 when params is informed', async () => {

--- a/projects/ion/src/lib/pagination/pagination.component.spec.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.spec.ts
@@ -35,7 +35,7 @@ describe('IonPaginationComponent', () => {
     await sut();
   });
 
-  it.each(['1', '2', '3', '4', '5'])(
+  it.each(['1', '2', '3', '4'])(
     'should render page %s',
     async (page: string) => {
       expect(screen.getByText(page)).toBeInTheDocument();

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -70,7 +70,7 @@ export class IonPaginationComponent implements OnChanges, OnInit {
     }
   }
 
-  selectPageOnClick(pageNumber: number) {
+  selectPageOnClick(pageNumber: number): void {
     if (pageNumber === this.page) {
       return;
     }

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -70,6 +70,13 @@ export class IonPaginationComponent implements OnChanges, OnInit {
     }
   }
 
+  selectPageOnClick(pageNumber: number) {
+    if (pageNumber === this.page) {
+      return;
+    }
+    this.selectPage(pageNumber);
+  }
+
   selectPage(pageNumber = 1, emitEvent = true): void {
     if (this.pages && !this.loading) {
       this.pages.forEach((pageEach) => {


### PR DESCRIPTION
## Issue Number

fix #655 

## Description

When clicking the button to navigate to the page that correspond to the current page, an event was emmited, so I defined a funcion that had a single responsability of handling the button click, and passed it to the click event on the component, so it could verify if the selcted page is the current and return if true, if not, executes the old function to emmit the event as expected.

## Proposed Changes

- Defined a new function with a Guard Clause to return early if the page selected was the one that was already active, and if not, just calls the selectPage function to do the logic as before;
- Passed this new function to the click replacing the previous one;
- Implemented a new test assertion to verify if no event was being emmited in this scenario.

## How to Test

run "yarn test pagination"

## View Storybook

[Storybook Link](https://62eab350a45bdb0a5818520e-uuwhzmovcm.chromatic.com/?path=/story/ion-feedback-alert--type-message)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.