### PR TITLE
fix: adjust width of badge

### DIFF
--- a/projects/ion/src/lib/badge/badge.component.scss
+++ b/projects/ion/src/lib/badge/badge.component.scss
@@ -12,6 +12,7 @@
     padding: spacing(0) spacing(0.5);
     border-radius: 50px;
     min-width: 8px;
+    box-sizing: content-box;
   }
 }
 


### PR DESCRIPTION
## Description

When there is only one number on the badge, its format is not a perfect circle, being slightly flattened. To achieve a better rounded effect, it is necessary that the width is at least equal to the height, which is 16px.

## Expected Behavior

When the badge contains a single digit number, it should be as close to a perfect circle as possible.