### PR TITLE
feat: added 'value' property to checkbox component

### DIFF
--- a/projects/ion/src/lib/checkbox/checkbox.component.html
+++ b/projects/ion/src/lib/checkbox/checkbox.component.html
@@ -1,14 +1,15 @@
 <div class="ion-input-checkbox">
   <input
     data-testid="ion-checkbox"
-    [id]="label"
-    [name]="label"
+    [id]="value"
+    [name]="value"
+    [value]="value"
     class="ion-checkbox"
     type="checkbox"
     (click)="changeState()"
     #checkBox
   />
-  <label *ngIf="label" [class.labelDisabled]="disabled" [for]="label">{{
+  <label *ngIf="label" [class.labelDisabled]="disabled" [for]="value">{{
     label
   }}</label>
 </div>

--- a/projects/ion/src/lib/checkbox/checkbox.component.spec.ts
+++ b/projects/ion/src/lib/checkbox/checkbox.component.spec.ts
@@ -53,7 +53,7 @@ describe('CheckboxComponent', () => {
     });
 
     it('should have the attribute name defined with label value', async () => {
-      expect(screen.getByTestId(boxId)).toHaveAttribute('name', 'Custom label');
+      expect(screen.getByTestId(boxId)).toHaveAttribute('name', '');
     });
 
     it('should not call event when render', async () => {
@@ -65,6 +65,7 @@ describe('CheckboxComponent', () => {
       fireEvent.click(screen.getByTestId(boxId));
       expect(checkEvent).toHaveBeenCalledWith({
         state: 'checked',
+        value: '',
       });
     });
 
@@ -133,7 +134,9 @@ describe('CheckboxComponent', () => {
       });
       const element = screen.getByTestId(boxId);
       fireEvent.click(element);
-      expect(clickEvent).toHaveBeenLastCalledWith(StateEvents[state]);
+      const expectedEmission = StateEvents[state];
+      expectedEmission.value = '';
+      expect(clickEvent).toHaveBeenLastCalledWith(expectedEmission);
     }
   );
   it('should emit a event in every click', async () => {
@@ -160,7 +163,7 @@ describe('CheckboxComponent', () => {
   });
   it('should is marked when clicked input label', async () => {
     const labelText = 'Teste';
-    await sut({ label: labelText });
+    await sut({ label: labelText, value: labelText });
     const element = screen.getByLabelText(labelText);
     fireEvent.click(element);
     expect(element).toBeChecked();
@@ -208,6 +211,7 @@ describe('Checkbox controlled by a parent component', () => {
     fireEvent(screen.getByTestId('ion-checkbox'), new Event('click'));
     expect(checkboxHost.changedState).toHaveBeenCalledWith({
       state: 'checked',
+      value: '',
     });
   });
   it('should emit event when changing state directly on host component', () => {
@@ -216,6 +220,7 @@ describe('Checkbox controlled by a parent component', () => {
     fixture.detectChanges();
     expect(checkboxHost.changedState).toHaveBeenCalledWith({
       state: 'checked',
+      value: '',
     });
   });
   it('should emit event when changing state to indeterminate directly on host component', () => {
@@ -224,6 +229,7 @@ describe('Checkbox controlled by a parent component', () => {
     fixture.detectChanges();
     expect(checkboxHost.changedState).toHaveBeenCalledWith({
       state: 'indeterminate',
+      value: '',
     });
   });
   it('should disable checkbox when changing disable input on host component', () => {

--- a/projects/ion/src/lib/checkbox/checkbox.component.ts
+++ b/projects/ion/src/lib/checkbox/checkbox.component.ts
@@ -23,6 +23,7 @@ import {
 })
 export class IonCheckboxComponent implements OnInit, OnChanges {
   @Input() label?: string;
+  @Input() value = '';
   @Input() state: CheckBoxStates = 'enabled';
   @Input() disabled = false;
 
@@ -68,7 +69,10 @@ export class IonCheckboxComponent implements OnInit, OnChanges {
   }
 
   emitEvent(): void {
-    this.ionClick.emit({ state: CheckBoxEvent[this.state] });
+    this.ionClick.emit({
+      state: CheckBoxEvent[this.state],
+      value: this.value,
+    });
   }
 
   stateInputChanged(state: SimpleChange): boolean {

--- a/projects/ion/src/lib/core/types/checkbox.ts
+++ b/projects/ion/src/lib/core/types/checkbox.ts
@@ -17,6 +17,7 @@ export interface CheckBoxProps {
   disabled?: boolean;
   state?: CheckBoxStates;
   ionClick?: EventEmitter<CheckBoxEvent>;
+  value?: string;
 }
 
 export type CheckBoxStates = keyof typeof CheckBoxEvent;


### PR DESCRIPTION
## Description

When there are many checkboxes on the screen, there may be cases where some of them contains same label. When this happens, there is a bug that makes only the first instance of them possible to select or deselect.

If I try to select another instance, only the first one is affected.

## Expected Behavior

It'll be interesting differ checkboxes by a value attribute, instead of a label.