### PR TITLE
682 add disabled state on tabgroup

### DIFF
--- a/projects/ion/src/lib/tab-group/tab-group.component.html
+++ b/projects/ion/src/lib/tab-group/tab-group.component.html
@@ -9,6 +9,7 @@
       [tabSize]="size"
       [direction]="border"
       [badge]="tab.badge"
+      [disabled]="tab.disabled"
     >
     </ion-tab>
   </div>

--- a/projects/ion/src/lib/tab-group/tab-group.component.spec.ts
+++ b/projects/ion/src/lib/tab-group/tab-group.component.spec.ts
@@ -147,4 +147,24 @@ describe('IonTabGroupComponent', () => {
     expect(screen.getByTestId('badge-tab')).toBeInTheDocument();
     expect(screen.getByText(badgeValue)).toBeInTheDocument();
   });
+
+  it('should have a disabled tab when informed', async () => {
+    const disabledTabLabel = 'disabled tab';
+    await sut({
+      direction: 'horizontal',
+      tabs: [
+        ...mockTabs,
+        {
+          label: disabledTabLabel,
+          selected: false,
+          disabled: true,
+        },
+      ],
+      selected: {
+        emit: selectEvent,
+      } as SafeAny,
+    });
+
+    expect(screen.getByText(disabledTabLabel)).toBeDisabled();
+  });
 });

--- a/stories/TabGroup.stories.ts
+++ b/stories/TabGroup.stories.ts
@@ -21,6 +21,7 @@ const tabs = [];
 for (let index = 1; index <= 8; index++) {
   tabs.push({
     label: 'Tab ' + index,
+
     selected: false,
   });
 }
@@ -37,6 +38,12 @@ export const Horizontal = Template.bind({});
 Horizontal.args = {
   tabs,
 
+  selected: action('selected'),
+};
+
+export const HorizontalDisabled = Template.bind({});
+HorizontalDisabled.args = {
+  tabs: [...tabs, { label: 'disabled tab', disabled: true }],
   selected: action('selected'),
 };
 


### PR DESCRIPTION
## Issue Number

fix #682 

## Description

The tab component have a disabled input property, but the tabgroup wasn't using it, so I added the property and passed to it the disabled expected value from the received tabs.

## Proposed Changes

- On the html of the tabgroup component, I passed the disabled property to the tab component, with the value from the current tab;
- created a story to verify the changes, passing one tab with the disabled true;
- created a test assertion to verify if, when is passed the disabled to true, the tab component is really disabled.

## How to Test

run yarn test tab-group, or check the story: horizontal disabled from the storybook

## Screenshots

![image](https://github.com/Brisanet/ion/assets/98463818/9eee2605-9376-49f2-98d6-56605a830152)

## View Storybook

[storybook](https://62eab350a45bdb0a5818520e-risyvibyuu.chromatic.com/?path=/story/ion-navigation-tabgroup--horizontal-disabled)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.
