### PR TITLE
683 add max length into select component

### DIFF
--- a/projects/ion/src/lib/core/types/dropdown.ts
+++ b/projects/ion/src/lib/core/types/dropdown.ts
@@ -12,7 +12,7 @@ export interface DropdownItem {
 export interface DropdownParams {
   options: DropdownItem[];
   selected: EventEmitter<DropdownItem[]>;
-  selectedMaxLength: number;
+  selectedMaxLength?: number;
   multiple?: boolean;
   required?: boolean;
   enableSearch?: boolean;

--- a/projects/ion/src/lib/core/types/dropdown.ts
+++ b/projects/ion/src/lib/core/types/dropdown.ts
@@ -12,7 +12,7 @@ export interface DropdownItem {
 export interface DropdownParams {
   options: DropdownItem[];
   selected: EventEmitter<DropdownItem[]>;
-  maxSelecteds?: number;
+  maxSelected?: number;
   multiple?: boolean;
   required?: boolean;
   enableSearch?: boolean;

--- a/projects/ion/src/lib/core/types/dropdown.ts
+++ b/projects/ion/src/lib/core/types/dropdown.ts
@@ -12,6 +12,7 @@ export interface DropdownItem {
 export interface DropdownParams {
   options: DropdownItem[];
   selected: EventEmitter<DropdownItem[]>;
+  selectedMaxLength: number;
   multiple?: boolean;
   required?: boolean;
   enableSearch?: boolean;

--- a/projects/ion/src/lib/core/types/dropdown.ts
+++ b/projects/ion/src/lib/core/types/dropdown.ts
@@ -12,7 +12,7 @@ export interface DropdownItem {
 export interface DropdownParams {
   options: DropdownItem[];
   selected: EventEmitter<DropdownItem[]>;
-  selectedMaxLength?: number;
+  maxSelecteds?: number;
   multiple?: boolean;
   required?: boolean;
   enableSearch?: boolean;

--- a/projects/ion/src/lib/core/types/select.ts
+++ b/projects/ion/src/lib/core/types/select.ts
@@ -8,7 +8,7 @@ export interface IonSelectProps {
   placeholder?: string;
   options?: DropdownItem[];
   events?: EventEmitter<DropdownItem[]>;
-  maxSelecteds?: number;
+  maxSelected?: number;
 }
 
 export interface IonSelectItemProps {

--- a/projects/ion/src/lib/core/types/select.ts
+++ b/projects/ion/src/lib/core/types/select.ts
@@ -8,7 +8,7 @@ export interface IonSelectProps {
   placeholder?: string;
   options?: DropdownItem[];
   events?: EventEmitter<DropdownItem[]>;
-  selectedMaxLength?: number;
+  maxSelecteds?: number;
 }
 
 export interface IonSelectItemProps {

--- a/projects/ion/src/lib/core/types/select.ts
+++ b/projects/ion/src/lib/core/types/select.ts
@@ -8,6 +8,7 @@ export interface IonSelectProps {
   placeholder?: string;
   options?: DropdownItem[];
   events?: EventEmitter<DropdownItem[]>;
+  selectedMaxLength?: number;
 }
 
 export interface IonSelectItemProps {

--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -302,6 +302,58 @@ describe('IonDropdownComponent / Multiple', () => {
   });
 });
 
+describe('IonDropdownComponent / Multiple With Max Length', () => {
+  const optionsWithMultiple = [
+    { label: 'Dog', selected: true },
+    { label: 'Cat', selected: false },
+    { label: 'Horse', selected: false },
+  ];
+
+  const defaultMultiple = {
+    options: optionsWithMultiple,
+    multiple: true,
+    selectedMaxLength: 1,
+    selected: {
+      emit: selectEvent,
+    } as SafeAny,
+  };
+
+  it('should not select an option when the defined limit was reached', async () => {
+    await sut(defaultMultiple);
+    const elementToSelect = document.getElementById('option-1');
+    fireEvent.click(elementToSelect);
+    expect(
+      document.getElementsByClassName('dropdown-item-selected')
+    ).toHaveLength(1);
+  });
+});
+
+describe('IonDropdownComponent / Default With Max Length', () => {
+  const optionsWithMultiple = [
+    { label: 'Dog', selected: true },
+    { label: 'Cat', selected: false },
+    { label: 'Horse', selected: false },
+  ];
+
+  const defaultMultiple = {
+    options: optionsWithMultiple,
+    multiple: false,
+    selectedMaxLength: 2,
+    selected: {
+      emit: selectEvent,
+    } as SafeAny,
+  };
+
+  it('should not select more than one option when passed an max length', async () => {
+    await sut(defaultMultiple);
+    const elementToSelect = document.getElementById('option-1');
+    fireEvent.click(elementToSelect);
+    expect(
+      document.getElementsByClassName('dropdown-item-selected')
+    ).toHaveLength(1);
+  });
+});
+
 describe('IonDropdownComponent / With Search', () => {
   const searchEvent = jest.fn();
 

--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -270,7 +270,7 @@ describe('IonDropdownComponent / Multiple With Max Length', () => {
   const defaultMultiple = {
     options: optionsWithMultiple,
     multiple: true,
-    selectedMaxLength: 1,
+    maxSelecteds: 1,
     selected: {
       emit: selectEvent,
     } as SafeAny,
@@ -296,7 +296,7 @@ describe('IonDropdownComponent / Default With Max Length', () => {
   const defaultMultiple = {
     options: optionsWithMultiple,
     multiple: false,
-    selectedMaxLength: 2,
+    maxSelecteds: 2,
     selected: {
       emit: selectEvent,
     } as SafeAny,

--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -280,8 +280,12 @@ describe('IonDropdownComponent / Multiple With Max Length', () => {
 
   it('should not select an option when the defined limit was reached', async () => {
     await sut(defaultMultiple);
-    const elementToSelect = document.getElementById('option-1');
+
+    let elementToSelect = document.getElementById('option-1');
     fireEvent.click(elementToSelect);
+    elementToSelect = document.getElementById('option-2');
+    fireEvent.click(elementToSelect);
+
     expect(
       document.getElementsByClassName('dropdown-item-selected')
     ).toHaveLength(maxSelectedQtd);
@@ -306,8 +310,12 @@ describe('IonDropdownComponent / Default With Max Length', () => {
 
   it('should not select more than one option when passed an max length', async () => {
     await sut(defaultMultiple);
-    const elementToSelect = document.getElementById('option-1');
+
+    let elementToSelect = document.getElementById('option-1');
     fireEvent.click(elementToSelect);
+    elementToSelect = document.getElementById('option-2');
+    fireEvent.click(elementToSelect);
+
     expect(
       document.getElementsByClassName('dropdown-item-selected')
     ).toHaveLength(1);

--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -267,10 +267,12 @@ describe('IonDropdownComponent / Multiple With Max Length', () => {
     { label: 'Horse', selected: false },
   ];
 
+  const maxSelectedQtd = 1;
+
   const defaultMultiple = {
     options: optionsWithMultiple,
     multiple: true,
-    maxSelecteds: 1,
+    maxSelected: maxSelectedQtd,
     selected: {
       emit: selectEvent,
     } as SafeAny,
@@ -282,7 +284,7 @@ describe('IonDropdownComponent / Multiple With Max Length', () => {
     fireEvent.click(elementToSelect);
     expect(
       document.getElementsByClassName('dropdown-item-selected')
-    ).toHaveLength(1);
+    ).toHaveLength(maxSelectedQtd);
   });
 });
 
@@ -296,7 +298,7 @@ describe('IonDropdownComponent / Default With Max Length', () => {
   const defaultMultiple = {
     options: optionsWithMultiple,
     multiple: false,
-    maxSelecteds: 2,
+    maxSelected: 2,
     selected: {
       emit: selectEvent,
     } as SafeAny,

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -26,6 +26,7 @@ export class IonDropdownComponent
 {
   @Input() options: DropdownItem[] = [];
   @Input() arraySelecteds: DropdownItem[] = [];
+  @Input() selectedMaxLength: DropdownParams['selectedMaxLength'];
   @Input() multiple?: DropdownParams['multiple'] = false;
   @Input() required?: DropdownParams['required'] = false;
   @Input() enableSearch = false;
@@ -44,10 +45,10 @@ export class IonDropdownComponent
 
   clearButtonIsVisible: boolean;
 
-  dropdownItens: Array<DropdownItem> = [];
+  dropdownSelectedItens: Array<DropdownItem> = [];
 
   setClearButtonIsVisible(): void {
-    const hasItems = this.checkArray(this.dropdownItens);
+    const hasItems = this.checkArray(this.dropdownSelectedItens);
     const showClearButton = !this.notShowClearButton;
 
     this.clearButtonIsVisible = showClearButton && hasItems && !this.required;
@@ -76,7 +77,7 @@ export class IonDropdownComponent
   clearEvent(): void {
     this.clearOptions();
     if (!this.multiple && !this.required) {
-      this.selected.emit(this.dropdownItens);
+      this.selected.emit(this.dropdownSelectedItens);
     }
     this.clearBadgeValue.emit();
   }
@@ -85,7 +86,7 @@ export class IonDropdownComponent
     this.options.forEach((item: DropdownItem) => {
       item.selected = false;
     });
-    this.dropdownItens = [];
+    this.dropdownSelectedItens = [];
     this.clearButtonIsVisible = false;
   }
 
@@ -123,21 +124,27 @@ export class IonDropdownComponent
   selectSingleOption(option: DropdownItem): void {
     this.clearOptions();
     option.selected = true;
-    this.dropdownItens = [option];
+    this.dropdownSelectedItens = [option];
     this.emitSelectedOptions();
   }
 
   manageMultipleOptions(option: DropdownItem): void {
-    if (this.dropdownItens) {
+    if (this.dropdownSelectedItens) {
       if (!option.selected) {
+        if (
+          this.selectedMaxLength &&
+          this.dropdownSelectedItens.length === this.selectedMaxLength
+        ) {
+          return;
+        }
         option.selected = true;
-        this.dropdownItens.push(option);
+        this.dropdownSelectedItens.push(option);
       } else {
         option.selected = false;
-        const index = this.dropdownItens.findIndex(
+        const index = this.dropdownSelectedItens.findIndex(
           (selectedOption) => selectedOption.label === option.label
         );
-        this.dropdownItens.splice(index, 1);
+        this.dropdownSelectedItens.splice(index, 1);
       }
     }
     this.emitSelectedOptions();
@@ -145,7 +152,7 @@ export class IonDropdownComponent
 
   emitSelectedOptions(): void {
     this.setClearButtonIsVisible();
-    this.selected.emit(this.dropdownItens);
+    this.selected.emit(this.dropdownSelectedItens);
   }
 
   inputChange(value: string): void {
@@ -165,16 +172,16 @@ export class IonDropdownComponent
   getSelected(): void {
     this.options.forEach((option) => {
       if (option.selected) {
-        this.dropdownItens.push(option);
+        this.dropdownSelectedItens.push(option);
       }
     });
 
     if (this.checkArray(this.arraySelecteds)) {
       this.arraySelecteds.forEach((option) => {
-        const duplicateOption = this.dropdownItens.find(
+        const duplicateOption = this.dropdownSelectedItens.find(
           (selectedOption) => selectedOption.label === option.label
         );
-        !duplicateOption && this.dropdownItens.push(option);
+        !duplicateOption && this.dropdownSelectedItens.push(option);
       });
     }
 
@@ -182,12 +189,12 @@ export class IonDropdownComponent
   }
 
   public ngOnDestroy(): void {
-    this.closeDropdown.emit(this.dropdownItens);
+    this.closeDropdown.emit(this.dropdownSelectedItens);
   }
 
   setSelected(): void {
-    if (this.checkArray(this.dropdownItens)) {
-      this.dropdownItens.forEach((selectedOption) => {
+    if (this.checkArray(this.dropdownSelectedItens)) {
+      this.dropdownSelectedItens.forEach((selectedOption) => {
         const option = this.options.find(
           (option) => option.label === selectedOption.label
         );
@@ -202,7 +209,7 @@ export class IonDropdownComponent
   }
 
   clickedOutsideDropdown(): void {
-    this.closeDropdown.emit(this.dropdownItens);
+    this.closeDropdown.emit(this.dropdownSelectedItens);
   }
 
   public ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -45,10 +45,10 @@ export class IonDropdownComponent
 
   clearButtonIsVisible: boolean;
 
-  dropdownSelectedItens: Array<DropdownItem> = [];
+  dropdownSelectedItems: Array<DropdownItem> = [];
 
   setClearButtonIsVisible(): void {
-    const hasItems = this.checkArray(this.dropdownSelectedItens);
+    const hasItems = this.checkArray(this.dropdownSelectedItems);
     const showClearButton = !this.notShowClearButton;
     if (this.multiple) {
       this.clearButtonIsVisible = showClearButton && hasItems && !this.required;
@@ -78,7 +78,7 @@ export class IonDropdownComponent
   clearEvent(): void {
     this.clearOptions();
     if (!this.multiple && !this.required) {
-      this.selected.emit(this.dropdownSelectedItens);
+      this.selected.emit(this.dropdownSelectedItems);
     }
   }
 
@@ -86,7 +86,7 @@ export class IonDropdownComponent
     this.options.forEach((item: DropdownItem) => {
       item.selected = false;
     });
-    this.dropdownSelectedItens = [];
+    this.dropdownSelectedItems = [];
     this.clearButtonIsVisible = false;
     this.clearBadgeValue.emit();
   }
@@ -109,17 +109,16 @@ export class IonDropdownComponent
     }
 
     if (this.multiple) {
-      if (!option.selected && this.isAtSelectedsMaxLength()) {
-        return;
-      }
       this.manageMultipleOptions(option);
       this.emitSelectedOptions();
       return;
     }
+
     if (!option.selected) {
       this.selectSingleOption(option);
       return;
     }
+
     if (this.required) {
       return;
     }
@@ -129,22 +128,26 @@ export class IonDropdownComponent
   selectSingleOption(option: DropdownItem): void {
     this.clearOptions();
     option.selected = true;
-    this.dropdownSelectedItens = [option];
+    this.dropdownSelectedItems = [option];
     this.emitSelectedOptions();
   }
 
   manageMultipleOptions(option: DropdownItem): void {
-    option.selected = !option.selected;
-
-    if (option.selected) {
-      this.dropdownSelectedItens.push(option);
+    if (!option.selected && this.isAtSelectedsMaxLength()) {
       return;
     }
 
-    const index = this.dropdownSelectedItens.findIndex(
+    option.selected = !option.selected;
+
+    if (option.selected) {
+      this.dropdownSelectedItems.push(option);
+      return;
+    }
+
+    const index = this.dropdownSelectedItems.findIndex(
       (selectedOption) => selectedOption.label === option.label
     );
-    this.dropdownSelectedItens.splice(index, 1);
+    this.dropdownSelectedItems.splice(index, 1);
   }
 
   isAtSelectedsMaxLength(): boolean {
@@ -154,7 +157,7 @@ export class IonDropdownComponent
 
   emitSelectedOptions(): void {
     this.setClearButtonIsVisible();
-    this.selected.emit(this.dropdownSelectedItens);
+    this.selected.emit(this.dropdownSelectedItems);
   }
 
   inputChange(value: string): void {
@@ -174,16 +177,16 @@ export class IonDropdownComponent
   getSelected(): void {
     this.options.forEach((option) => {
       if (option.selected) {
-        this.dropdownSelectedItens.push(option);
+        this.dropdownSelectedItems.push(option);
       }
     });
 
     if (this.checkArray(this.arraySelecteds)) {
       this.arraySelecteds.forEach((option) => {
-        const duplicateOption = this.dropdownSelectedItens.find(
+        const duplicateOption = this.dropdownSelectedItems.find(
           (selectedOption) => selectedOption.label === option.label
         );
-        !duplicateOption && this.dropdownSelectedItens.push(option);
+        !duplicateOption && this.dropdownSelectedItems.push(option);
       });
     }
 
@@ -191,12 +194,12 @@ export class IonDropdownComponent
   }
 
   public ngOnDestroy(): void {
-    this.closeDropdown.emit(this.dropdownSelectedItens);
+    this.closeDropdown.emit(this.dropdownSelectedItems);
   }
 
   setSelected(): void {
-    if (this.checkArray(this.dropdownSelectedItens)) {
-      this.dropdownSelectedItens.forEach((selectedOption) => {
+    if (this.checkArray(this.dropdownSelectedItems)) {
+      this.dropdownSelectedItems.forEach((selectedOption) => {
         const option = this.options.find(
           (option) => option.label === selectedOption.label
         );
@@ -211,7 +214,7 @@ export class IonDropdownComponent
   }
 
   clickedOutsideDropdown(): void {
-    this.closeDropdown.emit(this.dropdownSelectedItens);
+    this.closeDropdown.emit(this.dropdownSelectedItems);
   }
 
   public ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -26,7 +26,7 @@ export class IonDropdownComponent
 {
   @Input() options: DropdownItem[] = [];
   @Input() arraySelecteds: DropdownItem[] = [];
-  @Input() selectedMaxLength: DropdownParams['selectedMaxLength'];
+  @Input() selectedMaxLength?: DropdownParams['selectedMaxLength'];
   @Input() multiple?: DropdownParams['multiple'] = false;
   @Input() required?: DropdownParams['required'] = false;
   @Input() enableSearch = false;

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -26,7 +26,7 @@ export class IonDropdownComponent
 {
   @Input() options: DropdownItem[] = [];
   @Input() arraySelecteds: DropdownItem[] = [];
-  @Input() selectedMaxLength?: DropdownParams['selectedMaxLength'];
+  @Input() maxSelecteds?: DropdownParams['maxSelecteds'];
   @Input() multiple?: DropdownParams['multiple'] = false;
   @Input() required?: DropdownParams['required'] = false;
   @Input() enableSearch = false;
@@ -109,7 +109,11 @@ export class IonDropdownComponent
     }
 
     if (this.multiple) {
+      if (!option.selected && this.isAtSelectedsMaxLength()) {
+        return;
+      }
       this.manageMultipleOptions(option);
+      this.emitSelectedOptions();
       return;
     }
     if (!option.selected) {
@@ -130,26 +134,22 @@ export class IonDropdownComponent
   }
 
   manageMultipleOptions(option: DropdownItem): void {
-    if (this.dropdownSelectedItens) {
-      if (!option.selected) {
-        if (this.selectedMaxLength && this.isAtSelectedsMaxLength()) {
-          return;
-        }
-        option.selected = true;
-        this.dropdownSelectedItens.push(option);
-      } else {
-        option.selected = false;
-        const index = this.dropdownSelectedItens.findIndex(
-          (selectedOption) => selectedOption.label === option.label
-        );
-        this.dropdownSelectedItens.splice(index, 1);
-      }
+    option.selected = !option.selected;
+
+    if (option.selected) {
+      this.dropdownSelectedItens.push(option);
+      return;
     }
-    this.emitSelectedOptions();
+
+    const index = this.dropdownSelectedItens.findIndex(
+      (selectedOption) => selectedOption.label === option.label
+    );
+    this.dropdownSelectedItens.splice(index, 1);
   }
 
   isAtSelectedsMaxLength(): boolean {
-    return this.dropdownSelectedItens.length === this.selectedMaxLength;
+    const selectedOptions = this.options.filter((option) => option.selected);
+    return this.maxSelecteds && selectedOptions.length === this.maxSelecteds;
   }
 
   emitSelectedOptions(): void {

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -26,7 +26,7 @@ export class IonDropdownComponent
 {
   @Input() options: DropdownItem[] = [];
   @Input() arraySelecteds: DropdownItem[] = [];
-  @Input() maxSelecteds?: DropdownParams['maxSelecteds'];
+  @Input() maxSelected?: DropdownParams['maxSelected'];
   @Input() multiple?: DropdownParams['multiple'] = false;
   @Input() required?: DropdownParams['required'] = false;
   @Input() enableSearch = false;
@@ -152,7 +152,7 @@ export class IonDropdownComponent
 
   isAtSelectedsMaxLength(): boolean {
     const selectedOptions = this.options.filter((option) => option.selected);
-    return this.maxSelecteds && selectedOptions.length === this.maxSelecteds;
+    return this.maxSelected && selectedOptions.length === this.maxSelected;
   }
 
   emitSelectedOptions(): void {

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -131,10 +131,7 @@ export class IonDropdownComponent
   manageMultipleOptions(option: DropdownItem): void {
     if (this.dropdownSelectedItens) {
       if (!option.selected) {
-        if (
-          this.selectedMaxLength &&
-          this.dropdownSelectedItens.length === this.selectedMaxLength
-        ) {
+        if (this.selectedMaxLength && this.isAtSelectedsMaxLength()) {
           return;
         }
         option.selected = true;
@@ -148,6 +145,10 @@ export class IonDropdownComponent
       }
     }
     this.emitSelectedOptions();
+  }
+
+  isAtSelectedsMaxLength(): boolean {
+    return this.dropdownSelectedItens.length === this.selectedMaxLength;
   }
 
   emitSelectedOptions(): void {

--- a/projects/ion/src/lib/select/select.component.html
+++ b/projects/ion/src/lib/select/select.component.html
@@ -41,5 +41,5 @@
   [multiple]="mode === 'multiple'"
   (clearBadgeValue)="clearSelectedOptions()"
   (closeDropdown)="onCloseDropdown()"
-  [selectedMaxLength]="selectedMaxLength"
+  [maxSelecteds]="maxSelecteds"
 ></ion-dropdown>

--- a/projects/ion/src/lib/select/select.component.html
+++ b/projects/ion/src/lib/select/select.component.html
@@ -41,5 +41,5 @@
   [multiple]="mode === 'multiple'"
   (clearBadgeValue)="clearSelectedOptions()"
   (closeDropdown)="onCloseDropdown()"
-  [maxSelecteds]="maxSelecteds"
+  [maxSelected]="maxSelected"
 ></ion-dropdown>

--- a/projects/ion/src/lib/select/select.component.html
+++ b/projects/ion/src/lib/select/select.component.html
@@ -41,4 +41,5 @@
   [multiple]="mode === 'multiple'"
   (clearBadgeValue)="clearSelectedOptions()"
   (closeDropdown)="onCloseDropdown()"
+  [selectedMaxLength]="selectedMaxLength"
 ></ion-dropdown>

--- a/projects/ion/src/lib/select/select.component.ts
+++ b/projects/ion/src/lib/select/select.component.ts
@@ -19,7 +19,7 @@ export class IonSelectComponent implements OnInit {
   @Input() mode: IonSelectProps['mode'] = 'default';
   @Input() placeholder = '';
   @Input() options: IonSelectProps['options'] = [];
-  @Input() selectedMaxLength?: IonSelectProps['selectedMaxLength'];
+  @Input() maxSelecteds?: IonSelectProps['maxSelecteds'];
   @Output() events = new EventEmitter<IonSelectProps['options']>();
 
   showDropdown = false;

--- a/projects/ion/src/lib/select/select.component.ts
+++ b/projects/ion/src/lib/select/select.component.ts
@@ -19,7 +19,7 @@ export class IonSelectComponent implements OnInit {
   @Input() mode: IonSelectProps['mode'] = 'default';
   @Input() placeholder = '';
   @Input() options: IonSelectProps['options'] = [];
-  @Input() selectedMaxLength: IonSelectProps['selectedMaxLength'];
+  @Input() selectedMaxLength?: IonSelectProps['selectedMaxLength'];
   @Output() events = new EventEmitter<IonSelectProps['options']>();
 
   showDropdown = false;

--- a/projects/ion/src/lib/select/select.component.ts
+++ b/projects/ion/src/lib/select/select.component.ts
@@ -19,7 +19,7 @@ export class IonSelectComponent implements OnInit {
   @Input() mode: IonSelectProps['mode'] = 'default';
   @Input() placeholder = '';
   @Input() options: IonSelectProps['options'] = [];
-  @Input() maxSelecteds?: IonSelectProps['maxSelecteds'];
+  @Input() maxSelected?: IonSelectProps['maxSelected'];
   @Output() events = new EventEmitter<IonSelectProps['options']>();
 
   showDropdown = false;

--- a/projects/ion/src/lib/select/select.component.ts
+++ b/projects/ion/src/lib/select/select.component.ts
@@ -19,6 +19,7 @@ export class IonSelectComponent implements OnInit {
   @Input() mode: IonSelectProps['mode'] = 'default';
   @Input() placeholder = '';
   @Input() options: IonSelectProps['options'] = [];
+  @Input() selectedMaxLength: IonSelectProps['selectedMaxLength'];
   @Output() events = new EventEmitter<IonSelectProps['options']>();
 
   showDropdown = false;

--- a/stories/Select.stories.ts
+++ b/stories/Select.stories.ts
@@ -54,12 +54,12 @@ export const Default = Template.bind({});
 
 Default.args = {
   options: fruitOptions,
-  placeholder: 'Choose a fruit',
+  placeholder: 'Select 3 fruits',
 };
 
-export const Multiple = Template.bind({});
+export const MultipleMax3 = Template.bind({});
 
-Multiple.args = {
+MultipleMax3.args = {
   options: moreFruitOptions,
   placeholder: 'Select 3 fruits',
   mode: 'multiple',

--- a/stories/Select.stories.ts
+++ b/stories/Select.stories.ts
@@ -63,5 +63,5 @@ Multiple.args = {
   options: moreFruitOptions,
   placeholder: 'Choose a fruit',
   mode: 'multiple',
-  maxSelecteds: 3,
+  maxSelected: 3,
 };

--- a/stories/Select.stories.ts
+++ b/stories/Select.stories.ts
@@ -33,6 +33,18 @@ const fruitOptions: IonSelectProps['options'] = [
   { label: 'Grape', selected: false },
 ];
 
+const moreFruitOptions: IonSelectProps['options'] = [
+  { label: 'Apple', selected: false },
+  { label: 'Banana', selected: false },
+  { label: 'Grape', selected: false },
+  { label: 'Orange', selected: false },
+  { label: 'Lemon', selected: false },
+  { label: 'Avocado', selected: false },
+  { label: 'Watermelon', selected: false },
+  { label: 'Melon', selected: false },
+  { label: 'Strawberry', selected: false },
+];
+
 const Template: Story<IonSelectComponent> = (args: IonSelectProps) => ({
   component: IonSelectComponent,
   props: { ...args },
@@ -43,4 +55,13 @@ export const Default = Template.bind({});
 Default.args = {
   options: fruitOptions,
   placeholder: 'Choose a fruit',
+};
+
+export const Multiple = Template.bind({});
+
+Multiple.args = {
+  options: moreFruitOptions,
+  placeholder: 'Choose a fruit',
+  mode: 'multiple',
+  selectedMaxLength: 3,
 };

--- a/stories/Select.stories.ts
+++ b/stories/Select.stories.ts
@@ -61,7 +61,7 @@ export const Multiple = Template.bind({});
 
 Multiple.args = {
   options: moreFruitOptions,
-  placeholder: 'Choose a fruit',
+  placeholder: 'Select 3 fruits',
   mode: 'multiple',
   maxSelected: 3,
 };

--- a/stories/Select.stories.ts
+++ b/stories/Select.stories.ts
@@ -63,5 +63,5 @@ Multiple.args = {
   options: moreFruitOptions,
   placeholder: 'Choose a fruit',
   mode: 'multiple',
-  selectedMaxLength: 3,
+  maxSelecteds: 3,
 };


### PR DESCRIPTION
## Issue Number

fix #683 

## Description

The select didnt had a max length option, so to implement it, I added a property to the select component and to the dropdown, so it could be passed from one to another and the dropdown could be able to do the validation and work as expected.

## Proposed Changes

- Defined a Input property on the  components, select and dropdown;
- passed the maxLength to the dropdown on the html of the select;
- defined a guard to return early on the "manageMultipleOptions" method if the maxlength was already reached;
- implemented test assertions on the dropdown, to ensure these behaviors.

## How to Test

Run yarn test dropdown or check the story select with multiple option of the storybook

## View Storybook

[Storybook](https://62eab350a45bdb0a5818520e-cpcqmfwlrv.chromatic.com/)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.