### PR TITLE
290 create custom row to table

### DIFF
--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -1,145 +1,171 @@
 <div class="ion-table">
   <table data-testid="ion-table">
-    <tr class="border-header">
-      <th *ngIf="config.check" width="16">
-        <ion-checkbox
-          data-testid="table-check-all"
-          id="check-all"
-          name="check-all"
-          [state]="mainCheckBoxState"
-          (click)="checkState()"
-          [disabled]="!config?.data?.length"
-        >
-        </ion-checkbox>
-      </th>
-      <th
-        *ngFor="let column of config.columns"
-        [attr.data-testid]="'column-' + column.key"
-        [ngStyle]="{ width: column.width + '%' }"
-      >
-        <div class="header-style">
-          <span class="th-span">{{ column.label }}</span>
-          <button
-            class="svg"
-            (click)="
-              !!config.debounceOnSort ? sortWithDebounce(column) : sort(column)
-            "
-            *ngIf="column.sort"
+    <thead>
+      <tr class="border-header">
+        <th *ngIf="config.check" width="16">
+          <ion-checkbox
+            data-testid="table-check-all"
+            id="check-all"
+            name="check-all"
+            [state]="mainCheckBoxState"
+            (click)="checkState()"
+            [disabled]="!config?.data?.length"
           >
-            <svg
-              [attr.data-testid]="'sort-by-' + column.key"
-              width="8"
-              height="16"
-              viewBox="0 0 8 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.18015 0.103397C4.1005 -0.0344658 3.8995 -0.0344658 3.81985 0.103397L0.0276444 6.66693C-0.0513971 6.80373 0.0484804 6.97395 0.207794 6.97395H7.79221C7.95152 6.97395 8.0514 6.80373 7.97235 6.66693L4.18015 0.103397Z"
-                [attr.fill]="fillColor(column, true)"
-              />
-              <path
-                d="M3.81985 15.8966C3.8995 16.0345 4.1005 16.0345 4.18015 15.8966L7.97236 9.33307C8.0514 9.19627 7.95152 9.02605 7.79221 9.02605L0.207794 9.02605C0.0484809 9.02605 -0.0513966 9.19627 0.0276449 9.33307L3.81985 15.8966Z"
-                [attr.fill]="fillColor(column, false)"
-              />
-            </svg>
-          </button>
-        </div>
-      </th>
-      <th class="th-actions" *ngIf="config.actions && config.actions.length">
-        Ações
-      </th>
-    </tr>
-    <tr
-      *ngFor="let row of config.data; let index = index; let last = last"
-      [attr.data-testid]="'row-' + index"
-      [class.last-row]="last && !config.pagination"
-      [ngClass]="{
-        old: index % 2 === 0,
-        even: index % 2 !== 0,
-        checked: row.selected
-      }"
-    >
-      <td *ngIf="config.check" [attr.data-testid]="'row-' + index + '-td'">
-        <ion-checkbox
-          name="check-all"
-          id="check-all"
-          [state]="row.selected ? 'checked' : 'enabled'"
-          [attr.data-testid]="'row-' + index + '-check'"
-          (click)="checkRow(row)"
+          </ion-checkbox>
+        </th>
+        <th
+          *ngFor="let column of config.columns"
+          [attr.data-testid]="'column-' + column.key"
+          [ngStyle]="{ width: column.width + '%' }"
         >
-        </ion-checkbox>
-      </td>
-      <td
-        *ngFor="let column of config.columns"
-        [attr.data-testid]="'row-' + index + '-' + column.key"
-        [style.cursor]="column.actions && 'pointer'"
-        (click)="
-          column.actions &&
-            column.actions.trigger === 'click' &&
-            cellEvents(row, column, row[column.key])
-        "
-      >
-        <!-- cell types -->
-
-        <span class="td-span" *ngIf="!column.type">{{
-          row[column.key] | replaceEmpty: '-'
-        }}</span>
-        <ion-tag
-          *ngIf="column.type === 'tag'"
-          [label]="row[column.key]"
-          [status]="row[column.tag.statusKey] || column.tag.status"
-          [icon]="row[column.tag.iconKey] || column.tag.icon"
-        ></ion-tag>
-      </td>
-      <td *ngIf="config.actions">
-        <div class="icons-td">
-          <div *ngFor="let action of config.actions">
-            <ion-button
-              *ngIf="
-                action.confirm &&
-                (action.show ? !showAction(row, action) : true)
+          <div class="header-style">
+            <span class="th-span">{{ column.label }}</span>
+            <button
+              class="svg"
+              (click)="
+                !!config.debounceOnSort
+                  ? sortWithDebounce(column)
+                  : sort(column)
               "
-              ionPopConfirm
-              [ionPopConfirmTitle]="action.confirm.title"
-              [ionPopConfirmType]="action.confirm.type"
-              [ionPopConfirmDesc]="
-                !!action.confirm.description
-                  ? action.confirm.description
-                  : !!action.confirm.dynamicDescription
-                  ? action.confirm.dynamicDescription(row)
-                  : undefined
-              "
-              (ionOnConfirm)="handleEvent(row, action)"
-              [title]="action.label"
-              [attr.data-testid]="'row-' + index + '-' + action.label"
-              type="ghost"
-              size="sm"
-              [danger]="!!action.danger"
-              [iconType]="action.icon"
-              [circularButton]="true"
-              [disabled]="action.disabled ? !disableAction(row, action) : false"
-            ></ion-button>
-
-            <ion-button
-              *ngIf="
-                !action.confirm &&
-                (action.show ? !showAction(row, action) : true)
-              "
-              [title]="action.label"
-              [attr.data-testid]="'row-' + index + '-' + action.label"
-              type="ghost"
-              size="sm"
-              [danger]="!!action.danger"
-              [iconType]="action.icon"
-              [circularButton]="true"
-              (ionOnClick)="handleEvent(row, action)"
-              [disabled]="action.disabled ? !disableAction(row, action) : false"
-            ></ion-button>
+              *ngIf="column.sort"
+            >
+              <svg
+                [attr.data-testid]="'sort-by-' + column.key"
+                width="8"
+                height="16"
+                viewBox="0 0 8 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4.18015 0.103397C4.1005 -0.0344658 3.8995 -0.0344658 3.81985 0.103397L0.0276444 6.66693C-0.0513971 6.80373 0.0484804 6.97395 0.207794 6.97395H7.79221C7.95152 6.97395 8.0514 6.80373 7.97235 6.66693L4.18015 0.103397Z"
+                  [attr.fill]="fillColor(column, true)"
+                />
+                <path
+                  d="M3.81985 15.8966C3.8995 16.0345 4.1005 16.0345 4.18015 15.8966L7.97236 9.33307C8.0514 9.19627 7.95152 9.02605 7.79221 9.02605L0.207794 9.02605C0.0484809 9.02605 -0.0513966 9.19627 0.0276449 9.33307L3.81985 15.8966Z"
+                  [attr.fill]="fillColor(column, false)"
+                />
+              </svg>
+            </button>
           </div>
-        </div>
-      </td>
-    </tr>
+        </th>
+        <th class="th-actions" *ngIf="config.actions && config.actions.length">
+          Ações
+        </th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <ng-container
+        *ngFor="let row of config.data; let index = index; let last = last"
+      >
+        <tr
+          [attr.data-testid]="'row-' + index"
+          [class.last-row]="last && !config.pagination"
+          [ngClass]="{
+            old: index % 2 === 0,
+            even: index % 2 !== 0,
+            checked: row.selected
+          }"
+        >
+          <ng-container
+            *ngIf="config.customRowTemplate; else defaultTemplate"
+            [ngTemplateOutlet]="config.customRowTemplate"
+            [ngTemplateOutletContext]="{ $implicit: row }"
+          >
+          </ng-container>
+
+          <ng-template #defaultTemplate>
+            <td
+              *ngIf="config.check"
+              [attr.data-testid]="'row-' + index + '-td'"
+            >
+              <ion-checkbox
+                name="check-all"
+                id="check-all"
+                [state]="row.selected ? 'checked' : 'enabled'"
+                [attr.data-testid]="'row-' + index + '-check'"
+                (click)="checkRow(row)"
+              >
+              </ion-checkbox>
+            </td>
+            <td
+              *ngFor="let column of config.columns"
+              [attr.data-testid]="'row-' + index + '-' + column.key"
+              [style.cursor]="column.actions && 'pointer'"
+              (click)="
+                column.actions &&
+                  column.actions.trigger === 'click' &&
+                  cellEvents(row, column, row[column.key])
+              "
+            >
+              <!-- cell types -->
+
+              <span class="td-span" *ngIf="!column.type">{{
+                row[column.key] | replaceEmpty: '-'
+              }}</span>
+              <ion-tag
+                *ngIf="column.type === 'tag'"
+                [label]="row[column.key]"
+                [status]="row[column.tag.statusKey] || column.tag.status"
+                [icon]="row[column.tag.iconKey] || column.tag.icon"
+              ></ion-tag>
+            </td>
+            <td *ngIf="config.actions">
+              <div class="icons-td">
+                <div *ngFor="let action of config.actions">
+                  <ion-button
+                    *ngIf="
+                      action.confirm &&
+                      (action.show ? !showAction(row, action) : true)
+                    "
+                    ionPopConfirm
+                    [ionPopConfirmTitle]="action.confirm.title"
+                    [ionPopConfirmType]="action.confirm.type"
+                    [ionPopConfirmDesc]="
+                      !!action.confirm.description
+                        ? action.confirm.description
+                        : !!action.confirm.dynamicDescription
+                        ? action.confirm.dynamicDescription(row)
+                        : undefined
+                    "
+                    (ionOnConfirm)="handleEvent(row, action)"
+                    [title]="action.label"
+                    [attr.data-testid]="'row-' + index + '-' + action.label"
+                    type="ghost"
+                    size="sm"
+                    [danger]="!!action.danger"
+                    [iconType]="action.icon"
+                    [circularButton]="true"
+                    [disabled]="
+                      action.disabled ? !disableAction(row, action) : false
+                    "
+                  ></ion-button>
+
+                  <ion-button
+                    *ngIf="
+                      !action.confirm &&
+                      (action.show ? !showAction(row, action) : true)
+                    "
+                    [title]="action.label"
+                    [attr.data-testid]="'row-' + index + '-' + action.label"
+                    type="ghost"
+                    size="sm"
+                    [danger]="!!action.danger"
+                    [iconType]="action.icon"
+                    [circularButton]="true"
+                    (ionOnClick)="handleEvent(row, action)"
+                    [disabled]="
+                      action.disabled ? !disableAction(row, action) : false
+                    "
+                  ></ion-button>
+                </div>
+              </div>
+            </td>
+          </ng-template>
+        </tr>
+      </ng-container>
+    </tbody>
   </table>
 
   <div *ngIf="config.data && config.data.length === 0" class="noData">

--- a/projects/ion/src/lib/table/table.component.html
+++ b/projects/ion/src/lib/table/table.component.html
@@ -62,8 +62,8 @@
           }"
         >
           <ng-container
-            *ngIf="customRowTemplate; else defaultTemplate"
-            [ngTemplateOutlet]="customRowTemplate"
+            *ngIf="config.customRowTemplate; else defaultTemplate"
+            [ngTemplateOutlet]="config.customRowTemplate"
             [ngTemplateOutletContext]="{ $implicit: row }"
           >
           </ng-container>

--- a/projects/ion/src/lib/table/table.component.html
+++ b/projects/ion/src/lib/table/table.component.html
@@ -62,8 +62,8 @@
           }"
         >
           <ng-container
-            *ngIf="customTemplate; else defaultTemplate"
-            [ngTemplateOutlet]="customTemplate"
+            *ngIf="customRowTemplate; else defaultTemplate"
+            [ngTemplateOutlet]="customRowTemplate"
             [ngTemplateOutletContext]="{ $implicit: row }"
           >
           </ng-container>

--- a/projects/ion/src/lib/table/table.component.html
+++ b/projects/ion/src/lib/table/table.component.html
@@ -1,132 +1,157 @@
 <div class="ion-table">
   <table data-testid="ion-table">
-    <tr class="border-header">
-      <th *ngIf="config.check" width="16">
-        <ion-checkbox
-          data-testid="table-check-all"
-          id="check-all"
-          name="check-all"
-          [state]="mainCheckBoxState"
-          (click)="checkState()"
-          [disabled]="!config?.data?.length"
+    <thead>
+      <tr class="border-header">
+        <th *ngIf="config.check" width="16">
+          <ion-checkbox
+            data-testid="table-check-all"
+            id="check-all"
+            name="check-all"
+            [state]="mainCheckBoxState"
+            (click)="checkState()"
+            [disabled]="!config?.data?.length"
+          >
+          </ion-checkbox>
+        </th>
+        <th
+          *ngFor="let column of config.columns"
+          [attr.data-testid]="'column-' + column.key"
+          [ngStyle]="{ width: column.width + '%' }"
         >
-        </ion-checkbox>
-      </th>
-      <th
-        *ngFor="let column of config.columns"
-        [attr.data-testid]="'column-' + column.key"
-        [ngStyle]="{ width: column.width + '%' }"
-      >
-        <div class="header-style">
-          <span class="th-span">{{ column.label }}</span>
-          <button class="svg" (click)="sort(column)">
-            <svg
-              *ngIf="column.sort"
-              [attr.data-testid]="'sort-by-' + column.key"
-              width="8"
-              height="16"
-              viewBox="0 0 8 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4.18015 0.103397C4.1005 -0.0344658 3.8995 -0.0344658 3.81985 0.103397L0.0276444 6.66693C-0.0513971 6.80373 0.0484804 6.97395 0.207794 6.97395H7.79221C7.95152 6.97395 8.0514 6.80373 7.97235 6.66693L4.18015 0.103397Z"
-                [attr.fill]="fillColor(column, true)"
-              />
-              <path
-                d="M3.81985 15.8966C3.8995 16.0345 4.1005 16.0345 4.18015 15.8966L7.97236 9.33307C8.0514 9.19627 7.95152 9.02605 7.79221 9.02605L0.207794 9.02605C0.0484809 9.02605 -0.0513966 9.19627 0.0276449 9.33307L3.81985 15.8966Z"
-                [attr.fill]="fillColor(column, false)"
-              />
-            </svg>
-          </button>
-        </div>
-      </th>
-      <th class="th-actions" *ngIf="config.actions && config.actions.length">
-        Ações
-      </th>
-    </tr>
-
-    <tr
-      *ngFor="let row of smartData; let index = index; let last = last"
-      [attr.data-testid]="'row-' + index"
-      [class.last-row]="last && !config.pagination"
-      [ngClass]="{
-        old: index % 2 === 0,
-        even: index % 2 !== 0,
-        checked: row.selected
-      }"
-    >
-      <td *ngIf="config.check" [attr.data-testid]="'row-' + index + '-td'">
-        <ion-checkbox
-          name="check-all"
-          id="check-all"
-          [state]="row.selected ? 'checked' : 'enabled'"
-          [attr.data-testid]="'row-' + index + '-check'"
-          (click)="checkRow(row)"
-        >
-        </ion-checkbox>
-      </td>
-      <td
-        *ngFor="let column of config.columns"
-        [attr.data-testid]="'row-' + index + '-' + column.key"
-      >
-        <!-- cell types -->
-
-        <span class="td-span" *ngIf="!column.type">{{ row[column.key] }}</span>
-        <ion-tag
-          *ngIf="column.type === 'tag'"
-          [label]="row[column.key]"
-          [status]="row[column.tag.statusKey] || column.tag.status"
-          [icon]="row[column.tag.iconKey] || column.tag.icon"
-        ></ion-tag>
-      </td>
-      <td *ngIf="config.actions">
-        <div class="icons-td">
-          <div *ngFor="let action of config.actions">
-            <ion-button
-              *ngIf="
-                action.confirm &&
-                (action.show ? !showAction(row, action) : true)
-              "
-              ionPopConfirm
-              [ionPopConfirmTitle]="action.confirm.title"
-              [ionPopConfirmDesc]="
-                !!action.confirm.description
-                  ? action.confirm.description
-                  : !!action.confirm.dynamicDescription
-                  ? action.confirm.dynamicDescription(row)
-                  : undefined
-              "
-              (ionOnConfirm)="handleEvent(row, action)"
-              [title]="action.label"
-              [attr.data-testid]="'row-' + index + '-' + action.label"
-              type="ghost"
-              size="sm"
-              [danger]="!!action.danger"
-              [iconType]="action.icon"
-              [circularButton]="true"
-              [disabled]="action.disabled ? !disableAction(row, action) : false"
-            ></ion-button>
-
-            <ion-button
-              *ngIf="
-                !action.confirm &&
-                (action.show ? !showAction(row, action) : true)
-              "
-              [title]="action.label"
-              [attr.data-testid]="'row-' + index + '-' + action.label"
-              type="ghost"
-              size="sm"
-              [danger]="!!action.danger"
-              [iconType]="action.icon"
-              [circularButton]="true"
-              (ionOnClick)="handleEvent(row, action)"
-              [disabled]="action.disabled ? !disableAction(row, action) : false"
-            ></ion-button>
+          <div class="header-style">
+            <span class="th-span">{{ column.label }}</span>
+            <button class="svg" (click)="sort(column)">
+              <svg
+                *ngIf="column.sort"
+                [attr.data-testid]="'sort-by-' + column.key"
+                width="8"
+                height="16"
+                viewBox="0 0 8 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4.18015 0.103397C4.1005 -0.0344658 3.8995 -0.0344658 3.81985 0.103397L0.0276444 6.66693C-0.0513971 6.80373 0.0484804 6.97395 0.207794 6.97395H7.79221C7.95152 6.97395 8.0514 6.80373 7.97235 6.66693L4.18015 0.103397Z"
+                  [attr.fill]="fillColor(column, true)"
+                />
+                <path
+                  d="M3.81985 15.8966C3.8995 16.0345 4.1005 16.0345 4.18015 15.8966L7.97236 9.33307C8.0514 9.19627 7.95152 9.02605 7.79221 9.02605L0.207794 9.02605C0.0484809 9.02605 -0.0513966 9.19627 0.0276449 9.33307L3.81985 15.8966Z"
+                  [attr.fill]="fillColor(column, false)"
+                />
+              </svg>
+            </button>
           </div>
-        </div>
-      </td>
-    </tr>
+        </th>
+        <th class="th-actions" *ngIf="config.actions && config.actions.length">
+          Ações
+        </th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <ng-container
+        *ngFor="let row of smartData; let index = index; let last = last"
+      >
+        <tr
+          [attr.data-testid]="'row-' + index"
+          [class.last-row]="last && !config.pagination"
+          [ngClass]="{
+            old: index % 2 === 0,
+            even: index % 2 !== 0,
+            checked: row.selected
+          }"
+        >
+          <ng-container
+            *ngIf="customTemplate; else defaultTemplate"
+            [ngTemplateOutlet]="customTemplate"
+            [ngTemplateOutletContext]="{ $implicit: row }"
+          >
+          </ng-container>
+
+          <ng-template #defaultTemplate>
+            <td
+              *ngIf="config.check"
+              [attr.data-testid]="'row-' + index + '-td'"
+            >
+              <ion-checkbox
+                name="check-all"
+                id="check-all"
+                [state]="row.selected ? 'checked' : 'enabled'"
+                [attr.data-testid]="'row-' + index + '-check'"
+                (click)="checkRow(row)"
+              >
+              </ion-checkbox>
+            </td>
+            <td
+              *ngFor="let column of config.columns"
+              [attr.data-testid]="'row-' + index + '-' + column.key"
+            >
+              <!-- cell types -->
+
+              <span class="td-span" *ngIf="!column.type">{{
+                row[column.key]
+              }}</span>
+              <ion-tag
+                *ngIf="column.type === 'tag'"
+                [label]="row[column.key]"
+                [status]="row[column.tag.statusKey] || column.tag.status"
+                [icon]="row[column.tag.iconKey] || column.tag.icon"
+              ></ion-tag>
+            </td>
+            <td *ngIf="config.actions">
+              <div class="icons-td">
+                <div *ngFor="let action of config.actions">
+                  <ion-button
+                    *ngIf="
+                      action.confirm &&
+                      (action.show ? !showAction(row, action) : true)
+                    "
+                    ionPopConfirm
+                    [ionPopConfirmTitle]="action.confirm.title"
+                    [ionPopConfirmDesc]="
+                      !!action.confirm.description
+                        ? action.confirm.description
+                        : !!action.confirm.dynamicDescription
+                        ? action.confirm.dynamicDescription(row)
+                        : undefined
+                    "
+                    (ionOnConfirm)="handleEvent(row, action)"
+                    [title]="action.label"
+                    [attr.data-testid]="'row-' + index + '-' + action.label"
+                    type="ghost"
+                    size="sm"
+                    [danger]="!!action.danger"
+                    [iconType]="action.icon"
+                    [circularButton]="true"
+                    [disabled]="
+                      action.disabled ? !disableAction(row, action) : false
+                    "
+                  ></ion-button>
+
+                  <ion-button
+                    *ngIf="
+                      !action.confirm &&
+                      (action.show ? !showAction(row, action) : true)
+                    "
+                    [title]="action.label"
+                    [attr.data-testid]="'row-' + index + '-' + action.label"
+                    type="ghost"
+                    size="sm"
+                    [danger]="!!action.danger"
+                    [iconType]="action.icon"
+                    [circularButton]="true"
+                    (ionOnClick)="handleEvent(row, action)"
+                    [disabled]="
+                      action.disabled ? !disableAction(row, action) : false
+                    "
+                  ></ion-button>
+                </div>
+              </div>
+            </td>
+          </ng-template>
+        </tr>
+      </ng-container>
+    </tbody>
   </table>
   <div *ngIf="config.data && config.data.length === 0" class="noData">
     <ion-icon size="40" type="exclamation-rounded"></ion-icon>

--- a/projects/ion/src/lib/table/table.component.spec.ts
+++ b/projects/ion/src/lib/table/table.component.spec.ts
@@ -10,7 +10,14 @@ import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
 import { IonTagModule } from '../tag/tag.module';
 import { SafeAny } from '../utils/safe-any';
 import { IonTableComponent } from './table.component';
-import { ActionTable, Column, ColumnType } from './utilsTable';
+import { ActionTable, Column, ColumnType, ConfigTable } from './utilsTable';
+import {
+  AfterViewInit,
+  Component,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
+import { IonTableModule } from './table.module';
 
 const disabledArrowColor = '#CED2DB';
 const enabledArrowColor = '#0858CE';
@@ -710,5 +717,68 @@ describe('Table without Data and with checkBox', () => {
   it('checkbox should be disabled when there is no data', async () => {
     await sut(tableWithoutData);
     expect(screen.getByTestId('ion-checkbox')).toBeDisabled();
+  });
+});
+
+@Component({
+  selector: 'app',
+  template: ` <div>
+    <ion-table [config]="config"> </ion-table>
+    <ng-template #customTemplate let-row>
+      <td data-testid="custom-id-column">{{ row.id }}</td>
+      <td>
+        <div data-testid="custom-name-column">
+          <ion-icon type="user"></ion-icon>
+          <span> {{ row.name }} </span>
+        </div>
+      </td>
+    </ng-template>
+  </div>`,
+})
+export class WrapperCustomRowTemplateComponent implements AfterViewInit {
+  @ViewChild('customTemplate', { static: false })
+  customTemplate: TemplateRef<HTMLElement>;
+  config: ConfigTable<Disco>;
+
+  ngAfterViewInit(): void {
+    this.config = {
+      data,
+      columns,
+      customRowTemplate: this.customTemplate,
+    };
+  }
+}
+
+const sutCustomRowTemplate = async (
+  customProps: IonTableProps<Disco> = defaultProps
+): Promise<SafeAny> => {
+  await render(WrapperCustomRowTemplateComponent, {
+    componentProperties: customProps,
+    imports: [
+      FormsModule,
+      IonButtonModule,
+      IonIconModule,
+      IonCheckboxModule,
+      IonPaginationModule,
+      IonTagModule,
+      IonPopConfirmModule,
+      IonTableModule,
+    ],
+  });
+};
+
+describe('Table with custom row template', () => {
+  it('should render table with custom template', async () => {
+    await sutCustomRowTemplate();
+    expect(
+      await screen.getAllByTestId('custom-id-column').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('should render table with custom template', async () => {
+    await sutCustomRowTemplate();
+    expect(
+      await screen.getAllByTestId('custom-name-column').length
+    ).toBeGreaterThan(0);
   });
 });

--- a/projects/ion/src/lib/table/table.component.ts
+++ b/projects/ion/src/lib/table/table.component.ts
@@ -5,6 +5,7 @@ import {
   Input,
   OnInit,
   Output,
+  TemplateRef,
 } from '@angular/core';
 import { CheckBoxStates } from '../core/types/checkbox';
 import { PageEvent } from '../core/types/pagination';
@@ -25,6 +26,7 @@ const stateChange = {
 })
 export class IonTableComponent implements OnInit {
   @Input() config: ConfigTable<SafeAny>;
+  @Input() customRowTemplate?: TemplateRef<HTMLElement>;
   @Output() events = new EventEmitter<TableEvent>();
 
   public mainCheckBoxState: CheckBoxStates = 'enabled';

--- a/projects/ion/src/lib/table/table.component.ts
+++ b/projects/ion/src/lib/table/table.component.ts
@@ -5,7 +5,6 @@ import {
   Input,
   OnInit,
   Output,
-  TemplateRef,
 } from '@angular/core';
 import { CheckBoxStates } from '../core/types/checkbox';
 import { PageEvent } from '../core/types/pagination';
@@ -26,7 +25,6 @@ const stateChange = {
 })
 export class IonTableComponent implements OnInit {
   @Input() config: ConfigTable<SafeAny>;
-  @Input() customRowTemplate?: TemplateRef<HTMLElement>;
   @Output() events = new EventEmitter<TableEvent>();
 
   public mainCheckBoxState: CheckBoxStates = 'enabled';

--- a/projects/ion/src/lib/table/utilsTable.ts
+++ b/projects/ion/src/lib/table/utilsTable.ts
@@ -1,6 +1,7 @@
 import { TagStatus } from './../core/types/status';
 import { ConfigSmartTable, StatusType } from '../core/types';
 import { SafeAny } from '../utils/safe-any';
+import { TemplateRef } from '@angular/core';
 
 export enum EventTable {
   SORT = 'sort',
@@ -67,6 +68,7 @@ export interface ConfigTable<T> {
     column: string;
     desc: boolean | undefined;
   };
+  customRowTemplate?: TemplateRef<HTMLElement>;
 }
 
 export interface ColumnActions {

--- a/stories/Table.stories.ts
+++ b/stories/Table.stories.ts
@@ -296,3 +296,59 @@ PopConfirmDynamicDescription.args = {
     pagination: { total: 2, itemsPerPage: 2 },
   },
 };
+
+export const TableCustomRow = Template.bind({});
+TableCustomRow.args = {
+  config: {
+    columns,
+  },
+};
+
+TableCustomRow.parameters = {
+  docs: {
+    description: {
+      story: `Passos para customizar a linha da tabela.
+    1. No HTML do seu componente, crie um ng-template com a diretiva 'let-row' e realize as customizações desejadas.
+    A diretiva 'let-row' permite acessar os dados da linha através da identificação do objeto passado na configuração
+    da tabela. Veja o exemplo abaixo: 
+
+    <ng-template #customTemplate let-row>
+      <td>{{row.id}}</td>
+      <td>{{ row.name }}</td>
+      <td><ion-icon [type]="row.active ? 'check' : 'close'"></ion-icon></td>
+      <td>
+        <ion-icon
+          type="info"
+          (click)="onDetails(row)"
+          style="cursor: pointer"
+        ></ion-icon>
+      </td>
+    </ng-template>
+
+    2. No arquivo .ts do seu componente, utilize o decorator '@ViewChild' para obter a referência do template customizado
+    criado no arquivo HTML.  
+        
+    export class AppComponent implements OnInit {
+      @ViewChild("customTemplate", { static: true })
+      customTemplate: TemplateRef<HTMLElement>;
+
+      ...
+    }
+      
+    3. Passe a referência do template customizado para o atributo customRowTemplate da configuração da tabela.
+
+    export class AppComponent implements OnInit {
+      ...
+      
+      ngOnInit(): void {
+        this.config = {
+          data,
+          columns,
+          customRowTemplate:  this.customTemplate,
+        }
+      }
+    }
+      `,
+    },
+  },
+};


### PR DESCRIPTION
## Issue Number 

feat #290 

## Description

This PR adds the possibility to customize the table rows of the ion-table and ion-smart-table components

## View Storybook
In the Storybook it was not possible to recreate the example, but I left a step by step on how to use it.

https://62eab350a45bdb0a5818520e-xdclkvquht.chromatic.com/?path=/docs/ion-data-display-table--table-custom-row
