### PR TITLE
684 create no data component

### DIFF
--- a/projects/ion/src/lib/core/types/no-data.ts
+++ b/projects/ion/src/lib/core/types/no-data.ts
@@ -1,0 +1,6 @@
+import { IconType } from './icon';
+
+export interface IonNoDataProps {
+  label: string;
+  iconType?: IconType;
+}

--- a/projects/ion/src/lib/ion.module.ts
+++ b/projects/ion/src/lib/ion.module.ts
@@ -44,6 +44,7 @@ import { IonSpinnerModule } from './spinner/spinner.module';
 import { PipesModule } from './utils/pipes/pipes.module';
 import { IonSkeletonModule } from './skeleton/skeleton.module';
 import { IonSelectModule } from './select/select.module';
+import { IonNoDataModule } from './no-data/no-data.module';
 
 @NgModule({
   declarations: [IonComponent],
@@ -91,6 +92,7 @@ import { IonSelectModule } from './select/select.module';
     PipesModule,
     IonSelectModule,
     IonStepsModule,
+    IonNoDataModule,
   ],
   exports: [
     IonComponent,
@@ -135,6 +137,7 @@ import { IonSelectModule } from './select/select.module';
     IonSkeletonModule,
     IonSelectModule,
     IonStepsModule,
+    IonNoDataModule,
   ],
 })
 export class IonModule {}

--- a/projects/ion/src/lib/no-data/no-data.component.html
+++ b/projects/ion/src/lib/no-data/no-data.component.html
@@ -2,7 +2,7 @@
   <ion-icon
     data-testid="ion-no-data-icon"
     *ngIf="iconType"
-    [size]="12"
+    [size]="16"
     color="#8D93A5"
     [type]="iconType"
   ></ion-icon>

--- a/projects/ion/src/lib/no-data/no-data.component.html
+++ b/projects/ion/src/lib/no-data/no-data.component.html
@@ -1,0 +1,12 @@
+<div class="ion-no-data-container">
+  <ion-icon
+    data-testid="ion-no-data-icon"
+    *ngIf="iconType"
+    [size]="12"
+    color="#8D93A5"
+    [type]="iconType"
+  ></ion-icon>
+  <p class="ion-no-data-container__label">
+    {{ label }}
+  </p>
+</div>

--- a/projects/ion/src/lib/no-data/no-data.component.scss
+++ b/projects/ion/src/lib/no-data/no-data.component.scss
@@ -5,7 +5,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
 
   background-color: transparent;
 

--- a/projects/ion/src/lib/no-data/no-data.component.scss
+++ b/projects/ion/src/lib/no-data/no-data.component.scss
@@ -1,0 +1,18 @@
+@import '../../styles/index.scss';
+
+.ion-no-data-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+
+  background-color: transparent;
+
+  &__label {
+    color: $neutral-6;
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    @include font-size-xs;
+  }
+}

--- a/projects/ion/src/lib/no-data/no-data.component.spec.ts
+++ b/projects/ion/src/lib/no-data/no-data.component.spec.ts
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/angular';
+import { IonNoDataComponent } from './no-data.component';
+import { CommonModule } from '@angular/common';
+import { IonIconModule } from '../icon/icon.module';
+
+const defaultProps: IonNoDataComponent = {
+  label: 'Não há dados',
+  iconType: 'exclamation-rounded',
+};
+
+const sut = async (
+  customProps: IonNoDataComponent = defaultProps
+): Promise<void> => {
+  await render(IonNoDataComponent, {
+    componentProperties: customProps,
+    imports: [CommonModule, IonIconModule],
+  });
+};
+
+describe('IonNoDataComponent', () => {
+  beforeEach(async () => {
+    await sut();
+  });
+  it('Should render the informed text', async () => {
+    expect(screen.getByText('Não há dados')).toBeInTheDocument();
+  });
+
+  it('Should render a icon when informed', async () => {
+    expect(screen.getByTestId('ion-no-data-icon')).toBeInTheDocument();
+  });
+});

--- a/projects/ion/src/lib/no-data/no-data.component.ts
+++ b/projects/ion/src/lib/no-data/no-data.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ion-no-data',
+  templateUrl: './no-data.component.html',
+  styleUrls: ['./no-data.component.scss'],
+})
+export class IonNoDataComponent {
+  @Input() iconType?: string;
+  @Input() label: string;
+}

--- a/projects/ion/src/lib/no-data/no-data.component.ts
+++ b/projects/ion/src/lib/no-data/no-data.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { IconType } from '../core/types';
 
 @Component({
   selector: 'ion-no-data',
@@ -6,6 +7,6 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./no-data.component.scss'],
 })
 export class IonNoDataComponent {
-  @Input() iconType?: string;
+  @Input() iconType?: IconType;
   @Input() label: string;
 }

--- a/projects/ion/src/lib/no-data/no-data.module.ts
+++ b/projects/ion/src/lib/no-data/no-data.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { IonNoDataComponent } from './no-data.component';
+import { CommonModule } from '@angular/common';
+import { IonIconModule } from '../icon/icon.module';
+
+@NgModule({
+  declarations: [IonNoDataComponent],
+  imports: [CommonModule, IonIconModule],
+  exports: [IonNoDataComponent],
+})
+export class IonNoDataModule {}

--- a/projects/ion/src/public-api.ts
+++ b/projects/ion/src/public-api.ts
@@ -48,3 +48,4 @@ export * from './lib/step/step.module';
 export { default as debounce } from './lib/utils/debounce';
 export * from './lib/spinner/spinner.module';
 export * from './lib/select/select.module';
+export * from './lib/no-data/no-data.module';

--- a/stories/NoData.stories.ts
+++ b/stories/NoData.stories.ts
@@ -1,0 +1,24 @@
+import { CommonModule } from '@angular/common';
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import { IonNoDataComponent } from '../projects/ion/src/lib/no-data/no-data.component';
+import { IonNoDataModule } from '../projects/ion/src/lib/no-data/no-data.module';
+
+export default {
+  title: 'Ion/Data Display/No data',
+  component: IonNoDataComponent,
+} as Meta;
+
+const Template: Story<IonNoDataComponent> = (args: IonNoDataComponent) => ({
+  component: IonNoDataComponent,
+  props: { ...args },
+  moduleMetadata: {
+    imports: [CommonModule, IonNoDataModule],
+    entryComponents: [IonNoDataComponent],
+  },
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'Não há dados',
+  iconType: 'exclamation-rounded',
+};


### PR DESCRIPTION
## Issue Number

fix #684 

## Description

Implementation of the no data component with an optional custom icon and a custo text.

## Proposed Changes

- A new component with 2 inputs, one for the icontype and one for the label, that is the displayed text.

## How to Test

Run yarn test no-data

## Screenshots



## View Storybook



## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.