### PR TITLE
fix: update badge value when chip is create with option selected

### DIFF
--- a/projects/ion/src/lib/chip/chip.component.spec.ts
+++ b/projects/ion/src/lib/chip/chip.component.spec.ts
@@ -119,13 +119,25 @@ describe('ChipComponent', () => {
     expect(screen.getByText(labelBadge)).toBeInTheDocument();
   });
 
-  it('should render the label of the first selected option when displaying the chip with dropdwon', async () => {
+  it('should render the label of the first selected option when displaying the chip with dropdown', async () => {
     const customLabel = 'option';
     await sut({
       label: 'chip',
       options: [{ label: customLabel, selected: true }],
     });
     expect(screen.getByText(customLabel)).toBeInTheDocument();
+  });
+
+  it('should render badge with value', async () => {
+    await sut({
+      label: 'Chip',
+      options: [
+        { label: 'Option 1', selected: true },
+        { label: 'Option 2', selected: false },
+      ],
+      multiple: true,
+    });
+    expect(screen.getByTestId('badge-multiple')).toHaveTextContent('1');
   });
 
   describe('With Dropdown', () => {

--- a/projects/ion/src/lib/chip/chip.component.ts
+++ b/projects/ion/src/lib/chip/chip.component.ts
@@ -138,6 +138,10 @@ export class ChipComponent implements OnInit, AfterViewInit, DoCheck {
   ngOnInit(): void {
     this.chipId = this.generateId('ion-chip__container-');
     this.dropdownId = this.generateId('ion-chip__container-dropdown-');
+    const selecteds = this.getSelectedOptions();
+    if (selecteds && this.multiple) {
+      this.setBadgeValue(selecteds.length);
+    }
   }
 
   generateId = (name: string): string =>


### PR DESCRIPTION
fix #707

## Description

If you create a chip with an option already selected, the badge value will be updated.

## Proposed Changes

- Update the badge value on chip creation

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
