### PR TITLE
702 add tooltip in action button on table

### DIFF
--- a/projects/ion/src/lib/core/types/smart-table.ts
+++ b/projects/ion/src/lib/core/types/smart-table.ts
@@ -6,6 +6,7 @@ import {
 import { SafeAny } from '../../utils/safe-any';
 import { PageEvent } from './pagination';
 import { EventEmitter } from '@angular/core';
+import { TooltipProps } from './tooltip';
 
 export interface SmartTableEvent {
   event: EventTable;
@@ -26,4 +27,5 @@ export interface IonSmartTableProps<T> {
 export interface ConfigSmartTable<T> extends ConfigTable<T> {
   pagination: PaginationConfig;
   debounceOnSort?: number;
+  tooltipConfig?: TooltipProps;
 }

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -150,7 +150,9 @@
                   : undefined
               "
               (ionOnConfirm)="handleEvent(row, action)"
-              [attr.data-testid]="'row-' + index + '-' + action.label"
+              [attr.data-testid]="
+                'row-' + index + '-' + action.label + '-tooltip'
+              "
               type="ghost"
               size="sm"
               [danger]="!!action.danger"

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -138,6 +138,7 @@
               "
               [ionTooltipTrigger]="config.tooltipConfig.ionTooltipTrigger"
               [ionTooltipShowDelay]="config.tooltipConfig.ionTooltipShowDelay"
+              [ionTooltipTemplateRef]="ionTooltipTemplateBody"
               ionPopConfirm
               [ionPopConfirmTitle]="action.confirm.title"
               [ionPopConfirmType]="action.confirm.type"
@@ -217,3 +218,7 @@
     </div>
   </div>
 </div>
+
+<ng-template #ionTooltipTemplateBody>
+  <ng-container [ngTemplateOutlet]="ionTooltipTemplate"></ng-container>
+</ng-template>

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -98,8 +98,46 @@
             <ion-button
               *ngIf="
                 action.confirm &&
+                !config.tooltipConfig &&
                 (action.show ? !showAction(row, action) : true)
               "
+              ionPopConfirm
+              [ionPopConfirmTitle]="action.confirm.title"
+              [ionPopConfirmType]="action.confirm.type"
+              [ionPopConfirmDesc]="
+                !!action.confirm.description
+                  ? action.confirm.description
+                  : !!action.confirm.dynamicDescription
+                  ? action.confirm.dynamicDescription(row)
+                  : undefined
+              "
+              (ionOnConfirm)="handleEvent(row, action)"
+              [title]="action.label"
+              [attr.data-testid]="'row-' + index + '-' + action.label"
+              type="ghost"
+              size="sm"
+              [danger]="!!action.danger"
+              [iconType]="action.icon"
+              [circularButton]="true"
+              [disabled]="action.disabled ? !disableAction(row, action) : false"
+            ></ion-button>
+            <ion-button
+              *ngIf="
+                action.confirm &&
+                config.tooltipConfig &&
+                (action.show ? !showAction(row, action) : true)
+              "
+              ionTooltip
+              [ionTooltipTitle]="config.tooltipConfig.ionTooltipTitle"
+              [ionTooltipPosition]="config.tooltipConfig.ionTooltipPosition"
+              [ionTooltipArrowPointAtCenter]="
+                config.tooltipConfig.ionTooltipArrowPointAtCenter
+              "
+              [ionTooltipColorScheme]="
+                config.tooltipConfig.ionTooltipColorScheme
+              "
+              [ionTooltipTrigger]="config.tooltipConfig.ionTooltipTrigger"
+              [ionTooltipShowDelay]="config.tooltipConfig.ionTooltipShowDelay"
               ionPopConfirm
               [ionPopConfirmTitle]="action.confirm.title"
               [ionPopConfirmType]="action.confirm.type"

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -150,7 +150,6 @@
                   : undefined
               "
               (ionOnConfirm)="handleEvent(row, action)"
-              [title]="action.label"
               [attr.data-testid]="'row-' + index + '-' + action.label"
               type="ghost"
               size="sm"

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -11,6 +11,7 @@ import { IonTagModule } from '../tag/tag.module';
 import { PipesModule } from '../utils/pipes/pipes.module';
 import { SafeAny } from '../utils/safe-any';
 import { IonSmartTableComponent } from './smart-table.component';
+import { IonTooltipModule } from '../tooltip/tooltip.module';
 
 const disabledArrowColor = '#CED2DB';
 const enabledArrowColor = '#0858CE';
@@ -90,6 +91,7 @@ const sut = async (
       IonIconModule,
       IonPaginationModule,
       PipesModule,
+      IonTooltipModule,
     ],
   });
 };

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -1,8 +1,9 @@
+import { IonSmartTableProps } from './../core/types/smart-table';
 import { StatusType } from './../core/types/status';
 import { fireEvent, render, screen, within } from '@testing-library/angular';
 import { IonButtonModule } from '../button/button.module';
 import { IonCheckboxModule } from '../checkbox/checkbox.module';
-import { IonSmartTableProps } from '../core/types';
+import { TooltipPosition, TooltipProps, TooltipTrigger } from '../core/types';
 import { IonIconModule } from '../icon/icon.module';
 import { IonPaginationModule } from '../pagination/pagination.module';
 import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
@@ -835,6 +836,96 @@ describe('Table > Action with confirm', () => {
     // click in button again
     fireEvent.click(screen.getByTestId('row-0-Excluir'));
     expect(screen.getByText(cancelTextOnPopconfirm)).toBeInTheDocument();
+  });
+});
+
+describe('Table > Action with tooltip', () => {
+  const actions: ActionTable[] = [
+    {
+      label: 'Excluir',
+      icon: 'trash',
+      show: (row: Character): boolean => {
+        return !row.name;
+      },
+      confirm: {
+        title: 'Você tem certeza?',
+      },
+    },
+    {
+      label: 'Desabilitar',
+      icon: 'block',
+      disabled: (row: Character): boolean => {
+        return row.height > 160;
+      },
+      confirm: {
+        title: 'Você tem certeza?',
+      },
+    },
+    {
+      label: 'Editar',
+      icon: 'pencil',
+      call: (row: Character): void => {
+        row.name = 'editado!';
+      },
+      confirm: {
+        title: 'Você tem certeza?',
+      },
+    },
+  ];
+
+  const tooltipConfig: TooltipProps = {
+    ionTooltipTitle: 'Eu sou um tooltip',
+    ionTooltipPosition: TooltipPosition.DEFAULT,
+    ionTooltipTrigger: TooltipTrigger.DEFAULT,
+    ionTooltipColorScheme: 'dark',
+    ionTooltipArrowPointAtCenter: true,
+  };
+
+  const propsWithTooltip: IonSmartTableProps<Character> = {
+    ...defaultProps,
+    config: {
+      ...defaultProps.config,
+      actions,
+      tooltipConfig,
+    },
+  };
+
+  let actionButton: HTMLButtonElement;
+
+  beforeEach(async () => {
+    await sut(propsWithTooltip);
+    actionButton = screen.getByTestId(`row-0-${actions[0].label}-tooltip`);
+  });
+
+  it('should render without tooltip', async () => {
+    expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('should render the button with the tooltip directive when the tooltip configs are informed', async () => {
+    expect(actionButton).toBeInTheDocument();
+  });
+
+  it('should close the tooltip and open the popconfirm when clicked the button', () => {
+    fireEvent.mouseEnter(actionButton);
+    fireEvent.click(actionButton);
+    expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sup-container')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Luke Skywalker'));
+    expect(screen.queryByTestId('sup-container')).not.toBeInTheDocument();
+  });
+
+  it('should open the tooltip after a hover on the button', () => {
+    fireEvent.mouseEnter(actionButton);
+
+    expect(screen.getByTestId('ion-tooltip')).toBeInTheDocument();
+    fireEvent.mouseLeave(actionButton);
+  });
+
+  it('should close the tooltip after the mouse leave the button', () => {
+    fireEvent.mouseEnter(actionButton);
+    fireEvent.mouseLeave(actionButton);
+    expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
   });
 });
 

--- a/projects/ion/src/lib/smart-table/smart-table.component.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef,
+} from '@angular/core';
 import { ConfigSmartTable, SmartTableEvent } from '../core/types';
 import { CheckBoxStates } from '../core/types/checkbox';
 import { PageEvent } from '../core/types/pagination';
@@ -27,6 +34,7 @@ const stateChange = {
 })
 export class IonSmartTableComponent implements OnInit {
   @Input() config: ConfigSmartTable<SafeAny>;
+  @Input() ionTooltipTemplate?: TemplateRef<void>;
   @Output() events = new EventEmitter<SmartTableEvent>();
 
   public mainCheckBoxState: CheckBoxStates = 'enabled';

--- a/projects/ion/src/lib/smart-table/smart-table.module.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.module.ts
@@ -8,6 +8,7 @@ import { IonButtonModule } from '../button/button.module';
 import { IonIconModule } from '../icon/icon.module';
 import { IonPaginationModule } from '../pagination/pagination.module';
 import { PipesModule } from '../utils/pipes/pipes.module';
+import { IonTooltipModule } from '../tooltip/tooltip.module';
 
 @NgModule({
   declarations: [IonSmartTableComponent],
@@ -20,6 +21,7 @@ import { PipesModule } from '../utils/pipes/pipes.module';
     IonIconModule,
     IonPaginationModule,
     PipesModule,
+    IonTooltipModule,
   ],
   exports: [IonSmartTableComponent],
 })

--- a/projects/ion/src/lib/tooltip/tooltip.directive.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.ts
@@ -130,6 +130,8 @@ export class IonTooltipDirective implements OnDestroy {
       this.isComponentRefNull()
         ? this.attachComponentToView()
         : this.destroyComponent();
+    } else {
+      this.destroyComponent();
     }
   }
 

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -3,7 +3,11 @@ import { Meta, Story } from '@storybook/angular';
 import { LIST_OF_PAGE_OPTIONS } from '../projects/ion/src/lib/pagination/pagination.component';
 import { IonSmartTableComponent } from '../projects/ion/src/lib/smart-table/smart-table.component';
 import { SafeAny } from '../projects/ion/src/lib/utils/safe-any';
-import { IonSmartTableModule } from '../projects/ion/src/public-api';
+import {
+  IonSmartTableModule,
+  TooltipPosition,
+  TooltipTrigger,
+} from '../projects/ion/src/public-api';
 
 export default {
   title: 'Ion/Data Display/SmartTable',
@@ -155,13 +159,23 @@ const actions = [
   },
 ];
 
+const mockTooltip = {
+  ionTooltipTitle: 'Eu sou um tooltip',
+  ionTooltipPosition: TooltipPosition.DEFAULT,
+  ionTooltipTrigger: TooltipTrigger.DEFAULT,
+  ionTooltipColorScheme: 'dark',
+  ionTooltipShowDelay: 1000,
+  ionTooltipArrowPointAtCenter: true,
+};
+
 function returnTableConfig(
   tableData,
   tableColumns,
   tableActions,
   paginationTotal,
   debounceOnSort = 0,
-  pageSizeOptions = LIST_OF_PAGE_OPTIONS
+  pageSizeOptions = LIST_OF_PAGE_OPTIONS,
+  tooltipConfig?
 ): SafeAny {
   return {
     config: {
@@ -174,6 +188,7 @@ function returnTableConfig(
         pageSizeOptions,
       },
       debounceOnSort,
+      tooltipConfig: tooltipConfig,
     },
   };
 }
@@ -245,4 +260,15 @@ PopConfirmDynamicDescription.args = returnTableConfig(
     },
   ],
   2
+);
+
+export const WithTooltipInActions = Template.bind({});
+WithTooltipInActions.args = returnTableConfig(
+  data,
+  columns,
+  actions,
+  2,
+  2000,
+  [10, 15, 30, 50, 100],
+  mockTooltip
 );


### PR DESCRIPTION
## Issue Number

fix #702 

## Description

Implementation of the tooltip directive in the action buttons of the table. Were created two buttons that are conditionally displayed, if were informed tooltip configs, the button with the tooltip directive is rendered, if not, the regular one. It was also added a ngcontainer to receive a body to be passed to the tooltip. 

## Proposed Changes

- Tooltip directive adjusted to close the tooltip on click if the trigger mode is hover, so when the popconfirm is opened the tooltip doesnt stay behind it;
- Added a button with the tooltip directive on the smart table to be rendered when tooltip configs are informed;
- Tests implemented to verify if the popconfirm was still opening and the tooltip was working as expected.

## How to Test

Run yarn test smart-table and see the story 

## Screenshots

[Gravação de tela de 23-06-2023 09:18:19.webm](https://github.com/Brisanet/ion/assets/98463818/381093c8-8e18-4551-87fe-6f65b6571d76)

## View Storybook

[Storybook](https://62eab350a45bdb0a5818520e-niqzljctbo.chromatic.com/?path=/story/ion-data-display-smarttable--with-tooltip-in-actions)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.