### PR TITLE
feat: create template no data content in dropdown #526

### DIFF
--- a/projects/ion/src/lib/core/types/dropdown.ts
+++ b/projects/ion/src/lib/core/types/dropdown.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from '@angular/core';
 import { IonInputProps } from './input';
+import { IonNoDataProps } from './no-data';
 
 export interface DropdownItem {
   label: string;
@@ -19,4 +20,5 @@ export interface DropdownParams {
   searchOptions?: IonInputProps;
   searchChange?: EventEmitter<string>;
   notShowClearButton?: boolean;
+  noDataConfig?: IonNoDataProps;
 }

--- a/projects/ion/src/lib/dropdown/dropdown.component.html
+++ b/projects/ion/src/lib/dropdown/dropdown.component.html
@@ -57,4 +57,10 @@
     (click)="clearOptions(true)"
     data-testid="button-clear"
   ></ion-button>
+  <ion-no-data
+    *ngIf="!options || options.length === 0"
+    data-testid="ion-no-data"
+    [label]="noDataConfig.label"
+    [iconType]="noDataConfig.iconType"
+  ></ion-no-data>
 </div>

--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -526,14 +526,6 @@ describe('IonDropdownComponent / No data', () => {
     expect(element).not.toBeInTheDocument();
   });
 
-  it('Should render NoData with default parameters.', async () => {
-    await sut(defaultNoData);
-    expect(screen.getByText('Não há dados')).toBeInTheDocument();
-    expect(
-      document.getElementById('ion-icon-exclamation-rounded')
-    ).toBeInTheDocument();
-  });
-
   it('Should render NoData with custom parameters.', async () => {
     const noDataConfig = {
       label: 'Dados? Fugiram em férias!',

--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -497,3 +497,55 @@ describe('IonDropdownComponent / Required', () => {
     expect(document.getElementById('option-0')).toHaveClass('dropdown-item');
   });
 });
+
+describe('IonDropdownComponent / No data', () => {
+  const defaultNoData = {
+    ...defaultDropdown,
+    options: [],
+    selected: {
+      emit: selectEvent,
+    } as SafeAny,
+  };
+
+  it('Should render NoData when there are no options.', async () => {
+    await sut(defaultNoData);
+    const element = screen.getByTestId('ion-no-data');
+    expect(element).toBeInTheDocument();
+    expect(screen.getByText('Não há dados')).toBeInTheDocument();
+    expect(
+      document.getElementById('ion-icon-exclamation-rounded')
+    ).toBeInTheDocument();
+  });
+
+  it('Should not render NoData when there are options.', async () => {
+    await sut({
+      ...defaultNoData,
+      options: [{ label: 'Option 1', selected: false }],
+    });
+    const element = screen.queryByTestId('ion-no-data');
+    expect(element).not.toBeInTheDocument();
+  });
+
+  it('Should render NoData with default parameters.', async () => {
+    await sut(defaultNoData);
+    expect(screen.getByText('Não há dados')).toBeInTheDocument();
+    expect(
+      document.getElementById('ion-icon-exclamation-rounded')
+    ).toBeInTheDocument();
+  });
+
+  it('Should render NoData with custom parameters.', async () => {
+    const noDataConfig = {
+      label: 'Dados? Fugiram em férias!',
+      iconType: 'working',
+    };
+    await sut({
+      ...defaultNoData,
+      noDataConfig,
+    });
+    expect(screen.getByText(noDataConfig.label)).toBeInTheDocument();
+    expect(
+      document.getElementById(`ion-icon-${noDataConfig.iconType}`)
+    ).toBeInTheDocument();
+  });
+});

--- a/projects/ion/src/lib/dropdown/dropdown.component.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { DropdownItem, DropdownParams } from '../core/types/dropdown';
 import { SafeAny } from '../utils/safe-any';
+import { IonNoDataProps } from '../core/types/no-data';
 
 export const COLDOWN = 200;
 
@@ -32,6 +33,10 @@ export class IonDropdownComponent
   @Input() enableSearch = false;
   @Input() searchOptions?: DropdownParams['searchOptions'];
   @Input() notShowClearButton?: DropdownParams['notShowClearButton'] = false;
+  @Input() noDataConfig?: IonNoDataProps = {
+    label: 'Não há dados',
+    iconType: 'exclamation-rounded',
+  };
   @Output() selected = new EventEmitter<DropdownItem[]>();
   @Output() searchChange = new EventEmitter<string>();
   @Output() clearBadgeValue = new EventEmitter();

--- a/projects/ion/src/lib/no-data/no-data.component.spec.ts
+++ b/projects/ion/src/lib/no-data/no-data.component.spec.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/angular';
 import { IonNoDataComponent } from './no-data.component';
 import { CommonModule } from '@angular/common';
-import { IonIconModule } from '../icon/icon.module';
+import { IonSharedModule } from '../shared.module';
 
 const customLabel = 'No data';
 
@@ -13,7 +13,8 @@ const testCustomProps: IonNoDataComponent = {
 const sut = async (customProps?: IonNoDataComponent): Promise<void> => {
   await render(IonNoDataComponent, {
     componentProperties: customProps,
-    imports: [CommonModule, IonIconModule],
+    imports: [CommonModule, IonSharedModule],
+    excludeComponentDeclaration: true,
   });
 };
 

--- a/projects/ion/src/lib/no-data/no-data.module.ts
+++ b/projects/ion/src/lib/no-data/no-data.module.ts
@@ -1,11 +1,10 @@
 import { NgModule } from '@angular/core';
-import { IonNoDataComponent } from './no-data.component';
 import { CommonModule } from '@angular/common';
-import { IonIconModule } from '../icon/icon.module';
+import { IonNoDataComponent } from './no-data.component';
+import { IonSharedModule } from '../shared.module';
 
 @NgModule({
-  declarations: [IonNoDataComponent],
-  imports: [CommonModule, IonIconModule],
+  imports: [CommonModule, IonSharedModule],
   exports: [IonNoDataComponent],
 })
 export class IonNoDataModule {}

--- a/projects/ion/src/lib/shared.module.ts
+++ b/projects/ion/src/lib/shared.module.ts
@@ -7,6 +7,7 @@ import { IonDropdownComponent } from './dropdown/dropdown.component';
 import { IonIconComponent } from './icon/icon.component';
 import { IonInputComponent } from './input/input.component';
 import { ClickOutsideDirective } from './click-outside.directive';
+import { IonNoDataComponent } from './no-data/no-data.component';
 
 @NgModule({
   declarations: [
@@ -16,6 +17,7 @@ import { ClickOutsideDirective } from './click-outside.directive';
     IonBadgeComponent,
     IonInputComponent,
     ClickOutsideDirective,
+    IonNoDataComponent,
   ],
   imports: [CommonModule, FormsModule],
   exports: [
@@ -25,6 +27,7 @@ import { ClickOutsideDirective } from './click-outside.directive';
     IonBadgeComponent,
     IonInputComponent,
     ClickOutsideDirective,
+    IonNoDataComponent,
   ],
 })
 export class IonSharedModule {}

--- a/stories/Dropdown.stories.ts
+++ b/stories/Dropdown.stories.ts
@@ -42,6 +42,10 @@ Basic.args = {
 export const NoData = Template.bind({});
 NoData.args = {
   options: [],
+  noDataConfig: {
+    label: 'Dados? Fugiram em férias!',
+    iconType: 'exclamation-rounded',
+  },
 };
 
 export const DisabledSelected = Template.bind({});

--- a/stories/Dropdown.stories.ts
+++ b/stories/Dropdown.stories.ts
@@ -39,6 +39,11 @@ Basic.args = {
   options,
 };
 
+export const NoData = Template.bind({});
+NoData.args = {
+  options: [],
+};
+
 export const DisabledSelected = Template.bind({});
 DisabledSelected.args = {
   options: [


### PR DESCRIPTION
feat #526

noData template for when there are no options in the dropdown

Dropdown noData: 
![image](https://github.com/Brisanet/ion/assets/93842972/2fc9d756-652c-49f7-ae08-c5372b3a0787)

In the Select: 
![image](https://github.com/Brisanet/ion/assets/93842972/eacefc98-0a25-4f46-90db-1bc2503f7773)

In the Chip with search: 
![image](https://github.com/Brisanet/ion/assets/93842972/d787d7bd-e4aa-4d07-a3ba-564d5b198bab)




