### PR TITLE
fix: update is advanced on total changes

### DIFF
--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -78,6 +78,7 @@ export class IonPaginationComponent implements OnChanges, OnInit {
 
     if (changes.total) {
       this.remountPages(false);
+      this.updateIsAdvanced();
     }
 
     if (changes.page && changes.page.currentValue) {

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -4,7 +4,6 @@ import { LIST_OF_PAGE_OPTIONS } from '../projects/ion/src/lib/pagination/paginat
 import { IonSmartTableComponent } from '../projects/ion/src/lib/smart-table/smart-table.component';
 import { SafeAny } from '../projects/ion/src/lib/utils/safe-any';
 import {
-  IonSmartTableModule,
   TooltipPosition,
   TooltipTrigger,
   ConfigSmartTable,
@@ -180,7 +179,6 @@ function returnTableConfig(
   pageSizeOptions = LIST_OF_PAGE_OPTIONS,
   tooltipConfig?
 ): { config: ConfigSmartTable<SafeAny> } {
-
   return {
     config: {
       check: true,


### PR DESCRIPTION
## Issue Number

fix #724 

## Description

Called the updateIsAdvanced method on the ngOnChanges to update its state everytime the total of items is changed

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.