### PR TITLE
fix: fixing problem where whenever the total of items was changed, it…

### DIFF
--- a/projects/ion/src/lib/pagination/pagination.component.spec.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.spec.ts
@@ -8,6 +8,9 @@ import {
   IonPaginationComponent,
   LIST_OF_PAGE_OPTIONS,
 } from './pagination.component';
+import { Component, NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 const pageEvent = jest.fn();
 const defaultComponent: IonPaginationProps = {
@@ -383,5 +386,42 @@ describe('Advanced Pagination', () => {
         expect(screen.queryByTestId(`page-${page}`)).toBeNull();
       });
     });
+  });
+});
+
+const PAGE_SELECTED = 2;
+const TOTAL_ITEMS = 20;
+@Component({
+  template: `<ion-pagination [total]="total" [page]="page"> </ion-pagination>`,
+})
+class PaginationTestComponent {
+  total = TOTAL_ITEMS;
+  page = PAGE_SELECTED;
+}
+
+@NgModule({
+  declarations: [IonPaginationComponent, PaginationTestComponent],
+  imports: [CommonModule, IonButtonModule],
+  entryComponents: [PaginationTestComponent],
+})
+class TestModule {}
+
+describe('Pagination / Setting current page after total change', () => {
+  let paginationComponent!: PaginationTestComponent;
+  let fixture!: ComponentFixture<PaginationTestComponent>;
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [TestModule],
+    }).compileComponents();
+    fixture = TestBed.createComponent(PaginationTestComponent);
+    paginationComponent = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should show that after setting a page, even with a change in total, the selected page is the same as previously chosen', async () => {
+    paginationComponent.total = TOTAL_ITEMS + 1;
+    fixture.detectChanges();
+    expect(screen.getByTestId(`page-${PAGE_SELECTED}`)).toHaveClass('selected');
+    expect(document.getElementsByClassName('selected')).toHaveLength(1);
   });
 });

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -159,7 +159,7 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   remountPages(emitEvent = true): void {
     this.createPages(this.totalPages());
     if (this.pages.length) {
-      this.selectPage(1, emitEvent);
+      this.selectPage(this.page || 1, emitEvent);
     }
     this.updateIsAdvanced();
   }


### PR DESCRIPTION
fix #731

## Description

Currently, whenever there is a change in the pagination component in the total number of items, the pagination is redone, and the remountPages function set the page to 1 by default, which can be at the discretion of the developer who implemented the table.

## Proposed Changes

- If you pass a page, it will no longer return to page 1

## How to Test

Seven a page in the table configuration pagination and change the total items.

## View Storybook

[Storybook](https://62eab350a45bdb0a5818520e-kiebfiiyqp.chromatic.com/)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
