### PR TITLE
feat: not render tooltip when ionTooltipTitle is empty #747 

### DIFF
--- a/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
@@ -74,6 +74,14 @@ describe('Directive: Tooltip', () => {
     expect(screen.getByText(ionTooltipTitle)).toBeInTheDocument();
   });
 
+  it('should not render tooltip when ionTooltipTitle is empty', async () => {
+    const ionTooltipTitle = '';
+    await sut({ ionTooltipTitle });
+
+    fireEvent.mouseEnter(screen.getByTestId('hostTooltip'));
+    expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
+  });
+
   it('should render tooltip with a template ref', async () => {
     await sut();
 

--- a/projects/ion/src/lib/tooltip/tooltip.directive.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.ts
@@ -97,8 +97,10 @@ export class IonTooltipDirective implements OnDestroy {
   }
 
   attachComponentToView(): void {
-    document.body.appendChild(this.createComponent());
-    this.setComponentProperties();
+    if (this.ionTooltipTitle) {
+      document.body.appendChild(this.createComponent());
+      this.setComponentProperties();
+    }
   }
 
   showTooltip(): void {


### PR DESCRIPTION
#747 

The intention of this feature is to make it so that when an empty string is passed to the ionTooltipTitle, the tooltip will not be rendered

feat: #747 

before: 
![image](https://github.com/Brisanet/ion/assets/93842972/4dc2a5b5-0d74-44fc-81f1-e6f85fe69b92)



