### PR TITLE
Add required param on ion-select and emit event when unselect a option

### DIFF
--- a/projects/ion/src/lib/core/types/select.ts
+++ b/projects/ion/src/lib/core/types/select.ts
@@ -10,6 +10,7 @@ export interface IonSelectProps {
   events?: EventEmitter<DropdownItem[]>;
   maxSelected?: number;
   search?: EventEmitter<string>;
+  required?: boolean;
 }
 
 export interface IonSelectItemProps {

--- a/projects/ion/src/lib/select/select.component.html
+++ b/projects/ion/src/lib/select/select.component.html
@@ -2,7 +2,7 @@
   class="ion-select"
   (click)="handleClick()"
   data-testid="ion-select"
-  [class.ion-select__required]="isInvalid()"
+  [class.ion-select__required]="isValid"
 >
   <div class="ion-select-container">
     <ng-container *ngFor="let option of options; let i = index">
@@ -28,7 +28,7 @@
     <ion-icon
       class="icon"
       [type]="showDropdown ? 'semi-up' : 'semi-down'"
-      [color]="isInvalid() ? '#d6293a' : ''"
+      [color]="!isValid ? '' : '#d6293a'"
     ></ion-icon>
   </div>
 </div>

--- a/projects/ion/src/lib/select/select.component.html
+++ b/projects/ion/src/lib/select/select.component.html
@@ -2,7 +2,7 @@
   class="ion-select"
   (click)="handleClick()"
   data-testid="ion-select"
-  [class.ion-select-required]="isInValid()"
+  [class.ion-select__required]="isInvalid()"
 >
   <div class="ion-select-container">
     <ng-container *ngFor="let option of options; let i = index">
@@ -28,7 +28,7 @@
     <ion-icon
       class="icon"
       [type]="showDropdown ? 'semi-up' : 'semi-down'"
-      [color]="isInValid() ? '#d6293a' : ''"
+      [color]="isInvalid() ? '#d6293a' : ''"
     ></ion-icon>
   </div>
 </div>

--- a/projects/ion/src/lib/select/select.component.html
+++ b/projects/ion/src/lib/select/select.component.html
@@ -1,4 +1,9 @@
-<div class="ion-select" (click)="handleClick()" data-testid="ion-select">
+<div
+  class="ion-select"
+  (click)="handleClick()"
+  data-testid="ion-select"
+  [class.ion-select-required]="isInValid()"
+>
   <div class="ion-select-container">
     <ng-container *ngFor="let option of options; let i = index">
       <ng-container *ngIf="option.selected">
@@ -16,12 +21,14 @@
       [placeholder]="!hasSelectedOption() ? placeholder : ''"
       [(ngModel)]="inputValue"
       (input)="onSearchChange()"
+      [required]="required"
     />
   </div>
   <div>
     <ion-icon
       class="icon"
       [type]="showDropdown ? 'semi-up' : 'semi-down'"
+      [color]="isInValid() ? '#d6293a' : ''"
     ></ion-icon>
   </div>
 </div>

--- a/projects/ion/src/lib/select/select.component.scss
+++ b/projects/ion/src/lib/select/select.component.scss
@@ -66,3 +66,11 @@
     margin-inline-end: 8px;
   }
 }
+
+.ion-select-required {
+  border-color: $negative-color;
+
+  &:hover {
+    border-color: $negative-color;
+  }
+}

--- a/projects/ion/src/lib/select/select.component.scss
+++ b/projects/ion/src/lib/select/select.component.scss
@@ -67,7 +67,7 @@
   }
 }
 
-.ion-select-required {
+.ion-select__required {
   border-color: $negative-color;
 
   &:hover {

--- a/projects/ion/src/lib/select/select.component.spec.ts
+++ b/projects/ion/src/lib/select/select.component.spec.ts
@@ -160,8 +160,8 @@ describe('IonSelecComponent - mode: multiple', () => {
       const select = await screen.getByTestId('ion-select');
 
       userEvent.click(select);
-      fireEvent.click(await getOption(options[0].key));
-      fireEvent.click(await getOption(options[1].key));
+      userEvent.click(await getOption(options[0].key));
+      userEvent.click(await getOption(options[1].key));
 
       const selectItem = screen.getAllByTestId('ion-icon-close');
       userEvent.click(selectItem[0]);

--- a/projects/ion/src/lib/select/select.component.spec.ts
+++ b/projects/ion/src/lib/select/select.component.spec.ts
@@ -133,32 +133,22 @@ describe('IonSelecComponent - mode: multiple', () => {
         required: true,
       });
       const select = await screen.getByTestId('ion-select');
-      const el = document.createElement('div');
-      el.setAttribute('id', 'element-div');
-      el.style.height = '100px';
-      el.style.width = '100px';
-      document.body.appendChild(el);
 
       await userEvent.click(select);
-      await userEvent.dblClick(document.getElementById('element-div'));
+      userEvent.dblClick(document.body);
 
-      expect(select).toHaveClass('ion-select-required');
+      expect(select).toHaveClass('ion-select__required');
     });
     it('should not apply the required class if the parameter is false', async () => {
       await sut({
         options: getCopyOptions(),
       });
       const select = await screen.getByTestId('ion-select');
-      const el = document.createElement('div');
-      el.setAttribute('id', 'element-div');
-      el.style.height = '100px';
-      el.style.width = '100px';
-      document.body.appendChild(el);
 
       userEvent.click(select);
-      userEvent.dblClick(document.getElementById('element-div'));
+      userEvent.dblClick(document.body);
 
-      expect(select).not.toHaveClass('ion-select-required');
+      expect(select).not.toHaveClass('ion-select__required');
     });
     it('should not apply required class in multiple mode with an option checked', async () => {
       await sut({
@@ -168,11 +158,6 @@ describe('IonSelecComponent - mode: multiple', () => {
       });
 
       const select = await screen.getByTestId('ion-select');
-      const el = document.createElement('div');
-      el.setAttribute('id', 'element-div');
-      el.style.height = '100px';
-      el.style.width = '100px';
-      document.body.appendChild(el);
 
       userEvent.click(select);
       fireEvent.click(await getOption(options[0].key));
@@ -180,9 +165,9 @@ describe('IonSelecComponent - mode: multiple', () => {
 
       const selectItem = screen.getAllByTestId('ion-icon-close');
       userEvent.click(selectItem[0]);
-      userEvent.dblClick(document.getElementById('element-div'));
+      userEvent.dblClick(document.body);
 
-      expect(select).not.toHaveClass('ion-select-required');
+      expect(select).not.toHaveClass('ion-select__required');
     });
   });
 });

--- a/projects/ion/src/lib/select/select.component.spec.ts
+++ b/projects/ion/src/lib/select/select.component.spec.ts
@@ -126,4 +126,63 @@ describe('IonSelecComponent - mode: multiple', () => {
     userEvent.keyboard(textToType);
     expect(selectEvent).toHaveBeenCalledWith(textToType);
   });
+  describe('IonSelectComponent - required', () => {
+    it('should apply class required in select', async () => {
+      await sut({
+        options: getCopyOptions(),
+        required: true,
+      });
+      const select = await screen.getByTestId('ion-select');
+      const el = document.createElement('div');
+      el.setAttribute('id', 'element-div');
+      el.style.height = '100px';
+      el.style.width = '100px';
+      document.body.appendChild(el);
+
+      await userEvent.click(select);
+      await userEvent.dblClick(document.getElementById('element-div'));
+
+      expect(select).toHaveClass('ion-select-required');
+    });
+    it('should not apply the required class if the parameter is false', async () => {
+      await sut({
+        options: getCopyOptions(),
+      });
+      const select = await screen.getByTestId('ion-select');
+      const el = document.createElement('div');
+      el.setAttribute('id', 'element-div');
+      el.style.height = '100px';
+      el.style.width = '100px';
+      document.body.appendChild(el);
+
+      userEvent.click(select);
+      userEvent.dblClick(document.getElementById('element-div'));
+
+      expect(select).not.toHaveClass('ion-select-required');
+    });
+    it('should not apply required class in multiple mode with an option checked', async () => {
+      await sut({
+        options: getCopyOptions(),
+        required: true,
+        mode: 'multiple',
+      });
+
+      const select = await screen.getByTestId('ion-select');
+      const el = document.createElement('div');
+      el.setAttribute('id', 'element-div');
+      el.style.height = '100px';
+      el.style.width = '100px';
+      document.body.appendChild(el);
+
+      userEvent.click(select);
+      fireEvent.click(await getOption(options[0].key));
+      fireEvent.click(await getOption(options[1].key));
+
+      const selectItem = screen.getAllByTestId('ion-icon-close');
+      userEvent.click(selectItem[0]);
+      userEvent.dblClick(document.getElementById('element-div'));
+
+      expect(select).not.toHaveClass('ion-select-required');
+    });
+  });
 });

--- a/projects/ion/src/lib/select/select.component.ts
+++ b/projects/ion/src/lib/select/select.component.ts
@@ -29,7 +29,7 @@ export class IonSelectComponent implements OnInit {
   visibleOptions: IonSelectProps['options'] = [];
   showPlaceholder = true;
   private touched = false;
-  private isValue = false;
+  private hasValue = false;
 
   ngOnInit(): void {
     this.visibleOptions = this.options;
@@ -55,7 +55,7 @@ export class IonSelectComponent implements OnInit {
         option.selected = true;
       }
     }
-    this.isValue = !!selectedOptions.length;
+    this.hasValue = !!selectedOptions.length;
   }
 
   hasSelectedOption = (): boolean => {
@@ -70,7 +70,7 @@ export class IonSelectComponent implements OnInit {
     currentOption.selected = false;
     this.events.emit(this.options.filter((option) => option.selected));
     event.stopPropagation();
-    this.isValue = this.mode === 'default' ? false : this.hasSelectedOption();
+    this.hasValue = this.mode === 'default' ? false : this.hasSelectedOption();
   }
 
   onSearchChange(): void {
@@ -83,11 +83,11 @@ export class IonSelectComponent implements OnInit {
     this.search.emit(this.inputValue);
   }
 
-  isInValid(): boolean {
+  isInvalid(): boolean {
     if (!this.required) {
       return false;
     }
-    return this.touched && !this.isValue;
+    return this.touched && !this.hasValue;
   }
 
   onCloseDropdown(): void {

--- a/projects/ion/src/lib/select/select.component.ts
+++ b/projects/ion/src/lib/select/select.component.ts
@@ -20,6 +20,7 @@ export class IonSelectComponent implements OnInit {
   @Input() placeholder = '';
   @Input() options: IonSelectProps['options'] = [];
   @Input() maxSelected?: IonSelectProps['maxSelected'];
+  @Input() required: IonSelectProps['required'] = false;
   @Output() events = new EventEmitter<IonSelectProps['options']>();
   @Output() search = new EventEmitter<string>();
 
@@ -27,6 +28,8 @@ export class IonSelectComponent implements OnInit {
   inputValue = '';
   visibleOptions: IonSelectProps['options'] = [];
   showPlaceholder = true;
+  private touched = false;
+  private isValue = false;
 
   ngOnInit(): void {
     this.visibleOptions = this.options;
@@ -52,6 +55,7 @@ export class IonSelectComponent implements OnInit {
         option.selected = true;
       }
     }
+    this.isValue = !!selectedOptions.length;
   }
 
   hasSelectedOption = (): boolean => {
@@ -64,6 +68,9 @@ export class IonSelectComponent implements OnInit {
 
   unselectOption(currentOption: DropdownItem): void {
     currentOption.selected = false;
+    this.events.emit(this.options.filter((option) => option.selected));
+    event.stopPropagation();
+    this.isValue = this.mode === 'default' ? false : this.hasSelectedOption();
   }
 
   onSearchChange(): void {
@@ -76,9 +83,17 @@ export class IonSelectComponent implements OnInit {
     this.search.emit(this.inputValue);
   }
 
+  isInValid(): boolean {
+    if (!this.required) {
+      return false;
+    }
+    return this.touched && !this.isValue;
+  }
+
   onCloseDropdown(): void {
     if (this.showDropdown) {
       this.showDropdown = false;
+      this.touched = true;
     }
     this.inputValue = '';
     this.visibleOptions = this.options;

--- a/projects/ion/src/lib/select/select.component.ts
+++ b/projects/ion/src/lib/select/select.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   EventEmitter,
+  HostBinding,
   Input,
   OnInit,
   Output,
@@ -83,7 +84,8 @@ export class IonSelectComponent implements OnInit {
     this.search.emit(this.inputValue);
   }
 
-  isInvalid(): boolean {
+  @HostBinding('class.ion-select__required')
+  get isValid(): boolean {
     if (!this.required) {
       return false;
     }

--- a/stories/Select.stories.ts
+++ b/stories/Select.stories.ts
@@ -48,7 +48,7 @@ const moreFruitOptions: IonSelectProps['options'] = [
 
 const Template: Story<IonSelectComponent> = (args: IonSelectProps) => ({
   component: IonSelectComponent,
-  props: { ...args, search: action('search') },
+  props: { ...args, search: action('search'), events: action('events') },
 });
 
 export const Default = Template.bind({});
@@ -65,4 +65,11 @@ MultipleMax3.args = {
   placeholder: 'Select 3 fruits',
   mode: 'multiple',
   maxSelected: 3,
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  options: fruitOptions,
+  placeholder: 'Select 3 fruits',
+  required: true,
 };


### PR DESCRIPTION
## Add required param on ion-select and emit event when unselect a option

feat #749 

## Description

implemented required validation and issuing the field clear event

## Screenshots

![image](https://github.com/Brisanet/ion/assets/60994870/c460d457-d5d8-474e-bd76-403592908c1b)

## View Storybook

https://62eab350a45bdb0a5818520e-zjoxxufkdf.chromatic.com/?path=/story/ion-data-entry-select--required

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.

