### PR TITLE
fix: pagination selection when changing qtdPerPage

### DIFF
--- a/projects/ion/src/lib/pagination/pagination.component.spec.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.spec.ts
@@ -214,6 +214,19 @@ describe('Pagination > Events', () => {
     });
     expect(screen.queryAllByText('20 / página')).toHaveLength(1);
   });
+
+  it('should select the last page when itemsPerPage increases and the number of pages decreases', async () => {
+    await sut({
+      total: 21,
+      allowChangeQtdItems: true,
+    });
+
+    fireEvent.click(screen.getByTestId('page-3'));
+    fireEvent.click(screen.getByTestId('btn-10 / página'));
+    fireEvent.click(screen.getByText('20 / página'));
+
+    expect(screen.getByTestId('page-2')).toHaveClass('selected');
+  });
 });
 
 describe('Advanced Pagination', () => {

--- a/projects/ion/src/lib/pagination/pagination.component.ts
+++ b/projects/ion/src/lib/pagination/pagination.component.ts
@@ -159,7 +159,9 @@ export class IonPaginationComponent implements OnChanges, OnInit {
   remountPages(emitEvent = true): void {
     this.createPages(this.totalPages());
     if (this.pages.length) {
-      this.selectPage(this.page || 1, emitEvent);
+      const pageToSelect =
+        this.page > this.pages.length ? this.pages.length : this.page;
+      this.selectPage(pageToSelect || 1, emitEvent);
     }
     this.updateIsAdvanced();
   }


### PR DESCRIPTION
## Issue Number

fix #753 

## Description

This adds a validation on the remount method to check if the current page is still part of the pagination to call the function with the page number page as usual and if it isn't, the remount calls the selectPage with the last  page.
It was also added a test previously to ensure this behavior.

## How to Test

run yarn test pagination

## Screenshots

[Gravação de tela de 17-07-2023 16:29:42.webm](https://github.com/Brisanet/ion/assets/98463818/e7ed6405-cf7a-4867-aa3e-3c30e97bfed6)

## View Storybook

[Storybook](https://62eab350a45bdb0a5818520e-duoqhyotvk.chromatic.com/)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.