### PR TITLE
758 feat ellipsis on table cell

### DIFF
--- a/projects/ion/src/lib/core/types/smart-table.ts
+++ b/projects/ion/src/lib/core/types/smart-table.ts
@@ -1,11 +1,11 @@
+import { EventEmitter } from '@angular/core';
 import {
+  ConfigTable,
   EventTable,
   PaginationConfig,
-  ConfigTable,
 } from '../../table/utilsTable';
 import { SafeAny } from '../../utils/safe-any';
 import { PageEvent } from './pagination';
-import { EventEmitter } from '@angular/core';
 import { TooltipProps } from './tooltip';
 
 export interface SmartTableEvent {

--- a/projects/ion/src/lib/core/types/smart-table.ts
+++ b/projects/ion/src/lib/core/types/smart-table.ts
@@ -28,4 +28,5 @@ export interface ConfigSmartTable<T> extends ConfigTable<T> {
   pagination: PaginationConfig;
   debounceOnSort?: number;
   tooltipConfig?: TooltipProps;
+  hideLongData?: boolean;
 }

--- a/projects/ion/src/lib/core/types/smart-table.ts
+++ b/projects/ion/src/lib/core/types/smart-table.ts
@@ -29,5 +29,4 @@ export interface ConfigSmartTable<T> extends ConfigTable<T> {
   debounceOnSort?: number;
   tooltipConfig?: TooltipProps;
   hideLongData?: boolean;
-  cellTooltipConfig?: Partial<TooltipProps>;
 }

--- a/projects/ion/src/lib/core/types/smart-table.ts
+++ b/projects/ion/src/lib/core/types/smart-table.ts
@@ -29,4 +29,5 @@ export interface ConfigSmartTable<T> extends ConfigTable<T> {
   debounceOnSort?: number;
   tooltipConfig?: TooltipProps;
   hideLongData?: boolean;
+  cellTooltipConfig?: Partial<TooltipProps>;
 }

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -91,6 +91,7 @@
             </td>
             <td
               *ngFor="let column of config.columns"
+              [ngClass]="{ 'hidden-content': config.hideLongData }"
               [attr.data-testid]="'row-' + index + '-' + column.key"
               [style.cursor]="column.actions && 'pointer'"
               (click)="
@@ -98,6 +99,9 @@
                   column.actions.trigger === 'click' &&
                   cellEvents(row, column, row[column.key])
               "
+              ionTooltip
+              [ionTooltipTitle]="config.hideLongData && row[column.key]"
+              ionTooltipColorScheme="dark"
             >
               <!-- cell types -->
 

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -105,7 +105,18 @@
                 cell.offsetWidth < cell.scrollWidth &&
                 row[column.key]
               "
-              ionTooltipColorScheme="dark"
+              [ionTooltipColorScheme]="
+                config.cellTooltipConfig?.ionTooltipColorScheme || 'dark'
+              "
+              [ionTooltipPosition]="
+                config.cellTooltipConfig?.ionTooltipPosition || 'bottomLeft'
+              "
+              [ionTooltipShowDelay]="
+                config.cellTooltipConfig?.ionTooltipShowDelay || 0
+              "
+              [ionTooltipTrigger]="
+                config.cellTooltipConfig?.ionTooltipTrigger || 'hover'
+              "
               #cell
             >
               <!-- cell types -->

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -100,8 +100,13 @@
                   cellEvents(row, column, row[column.key])
               "
               ionTooltip
-              [ionTooltipTitle]="config.hideLongData && row[column.key]"
+              [ionTooltipTitle]="
+                config.hideLongData &&
+                cell.offsetWidth < cell.scrollWidth &&
+                row[column.key]
+              "
               ionTooltipColorScheme="dark"
+              #cell
             >
               <!-- cell types -->
 

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -105,18 +105,7 @@
                 cell.offsetWidth < cell.scrollWidth &&
                 row[column.key]
               "
-              [ionTooltipColorScheme]="
-                config.cellTooltipConfig?.ionTooltipColorScheme || 'dark'
-              "
-              [ionTooltipPosition]="
-                config.cellTooltipConfig?.ionTooltipPosition || 'bottomLeft'
-              "
-              [ionTooltipShowDelay]="
-                config.cellTooltipConfig?.ionTooltipShowDelay || 0
-              "
-              [ionTooltipTrigger]="
-                config.cellTooltipConfig?.ionTooltipTrigger || 'hover'
-              "
+              ionTooltipColorScheme="dark"
               #cell
             >
               <!-- cell types -->

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -91,7 +91,7 @@
             </td>
             <td
               *ngFor="let column of config.columns"
-              [ngClass]="{ 'hidden-content': config.hideLongData }"
+              [class.hidden-content]="config.hideLongData"
               [attr.data-testid]="'row-' + index + '-' + column.key"
               [style.cursor]="column.actions && 'pointer'"
               (click)="

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -62,6 +62,16 @@ const data: Character[] = [
   },
 ];
 
+const longData: Character[] = [
+  {
+    name: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Vero, voluptatibus veniam reiciendis repellendus laborum nam laboriosam est natus ut, delectus iure quis consequuntur eligendi aspernatur, corporis voluptates nulla assumenda adipisci. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Vero, voluptatibus veniam reiciendis repellendus laborum nam laboriosam est natus ut, delectus iure quis consequuntur eligendi aspernatur, corporis voluptates nulla assumenda adipisci. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Vero, voluptatibus veniam reiciendis repellendus laborum nam laboriosam est natus ut, delectus iure quis consequuntur eligendi aspernatur, corporis voluptates nulla assumenda adipisci.',
+    height: 0,
+    mass: 0,
+    icon: 'box',
+    status: 'negative',
+  },
+];
+
 const events = jest.fn();
 
 const defaultProps: IonSmartTableProps<Character> = {
@@ -1065,5 +1075,26 @@ describe('Table with cell events', () => {
         },
       },
     });
+  });
+});
+
+describe('Table > Cell with long data', () => {
+  const tableWithLongData = {
+    ...defaultProps,
+    config: {
+      ...defaultProps.config,
+      data: longData,
+    },
+  };
+
+  it('should render without the hidden-content class as default', async () => {
+    await sut(tableWithLongData);
+    expect(screen.getByTestId('row-0-name')).not.toHaveClass('hidden-content');
+  });
+
+  it('should render with the hidden-content class when hideLongData is provided', async () => {
+    tableWithLongData.config.hideLongData = true;
+    await sut(tableWithLongData);
+    expect(screen.getByTestId('row-0-name')).toHaveClass('hidden-content');
   });
 });

--- a/projects/ion/src/lib/smart-table/smart-table.component.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.ts
@@ -1,4 +1,6 @@
 import {
+  AfterViewChecked,
+  ChangeDetectorRef,
   Component,
   EventEmitter,
   Input,
@@ -32,7 +34,7 @@ const stateChange = {
   templateUrl: './smart-table.component.html',
   styleUrls: ['../table/table.component.scss'],
 })
-export class IonSmartTableComponent implements OnInit {
+export class IonSmartTableComponent implements OnInit, AfterViewChecked {
   @Input() config: ConfigSmartTable<SafeAny>;
   @Input() ionTooltipTemplate?: TemplateRef<void>;
   @Output() events = new EventEmitter<SmartTableEvent>();
@@ -43,6 +45,8 @@ export class IonSmartTableComponent implements OnInit {
 
   private firstLoad = true;
   private tableUtils: TableUtils;
+
+  constructor(private cdr: ChangeDetectorRef) {}
 
   ngOnInit(): void {
     this.tableUtils = new TableUtils(this.config);
@@ -57,6 +61,10 @@ export class IonSmartTableComponent implements OnInit {
         this.sort(column);
       }, this.config.debounceOnSort);
     }
+  }
+
+  ngAfterViewChecked(): void {
+    this.cdr.detectChanges();
   }
 
   public checkState(): void {

--- a/projects/ion/src/lib/smart-table/smart-table.component.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.ts
@@ -1,9 +1,13 @@
 import {
+  AfterViewChecked,
+  ChangeDetectorRef,
   Component,
   EventEmitter,
   Input,
+  OnChanges,
   OnInit,
   Output,
+  SimpleChanges,
   TemplateRef,
 } from '@angular/core';
 import { ConfigSmartTable, SmartTableEvent } from '../core/types';
@@ -32,7 +36,7 @@ const stateChange = {
   templateUrl: './smart-table.component.html',
   styleUrls: ['../table/table.component.scss'],
 })
-export class IonSmartTableComponent implements OnInit {
+export class IonSmartTableComponent implements OnInit, AfterViewChecked {
   @Input() config: ConfigSmartTable<SafeAny>;
   @Input() ionTooltipTemplate?: TemplateRef<void>;
   @Output() events = new EventEmitter<SmartTableEvent>();
@@ -43,6 +47,8 @@ export class IonSmartTableComponent implements OnInit {
 
   private firstLoad = true;
   private tableUtils: TableUtils;
+
+  constructor(private cdr: ChangeDetectorRef) {}
 
   ngOnInit(): void {
     this.tableUtils = new TableUtils(this.config);
@@ -57,6 +63,10 @@ export class IonSmartTableComponent implements OnInit {
         this.sort(column);
       }, this.config.debounceOnSort);
     }
+  }
+
+  ngAfterViewChecked(): void {
+    this.cdr.detectChanges();
   }
 
   public checkState(): void {

--- a/projects/ion/src/lib/smart-table/smart-table.component.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.ts
@@ -1,13 +1,9 @@
 import {
-  AfterViewChecked,
-  ChangeDetectorRef,
   Component,
   EventEmitter,
   Input,
-  OnChanges,
   OnInit,
   Output,
-  SimpleChanges,
   TemplateRef,
 } from '@angular/core';
 import { ConfigSmartTable, SmartTableEvent } from '../core/types';
@@ -36,7 +32,7 @@ const stateChange = {
   templateUrl: './smart-table.component.html',
   styleUrls: ['../table/table.component.scss'],
 })
-export class IonSmartTableComponent implements OnInit, AfterViewChecked {
+export class IonSmartTableComponent implements OnInit {
   @Input() config: ConfigSmartTable<SafeAny>;
   @Input() ionTooltipTemplate?: TemplateRef<void>;
   @Output() events = new EventEmitter<SmartTableEvent>();
@@ -47,8 +43,6 @@ export class IonSmartTableComponent implements OnInit, AfterViewChecked {
 
   private firstLoad = true;
   private tableUtils: TableUtils;
-
-  constructor(private cdr: ChangeDetectorRef) {}
 
   ngOnInit(): void {
     this.tableUtils = new TableUtils(this.config);
@@ -63,10 +57,6 @@ export class IonSmartTableComponent implements OnInit, AfterViewChecked {
         this.sort(column);
       }, this.config.debounceOnSort);
     }
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges();
   }
 
   public checkState(): void {

--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -99,6 +99,7 @@ table {
       font-weight: 400;
       line-height: 20px;
       color: $neutral-7;
+      word-break: break-all;
     }
 
     & input {

--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -212,13 +212,8 @@ table {
 }
 
 .hidden-content {
-  max-width: 200px;
+  max-width: 0;
   overflow-x: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-
-  /* &:hover {
-    overflow-x: initial;
-    white-space: break-spaces;
-  } */
 }

--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -99,7 +99,6 @@ table {
       font-weight: 400;
       line-height: 20px;
       color: $neutral-7;
-      word-break: break-all;
     }
 
     & input {
@@ -210,4 +209,16 @@ table {
   ::ng-deep ion-icon svg {
     fill: $neutral-6;
   }
+}
+
+.hidden-content {
+  max-width: 200px;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  /* &:hover {
+    overflow-x: initial;
+    white-space: break-spaces;
+  } */
 }

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -225,8 +225,8 @@ function returnTableConfig(
         pageSizeOptions,
       },
       debounceOnSort,
-      tooltipConfig: tooltipConfig,
-      hideLongData: hideLongData,
+      tooltipConfig,
+      hideLongData,
     },
   };
 }

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -40,6 +40,8 @@ const longData = [
     deleted: false,
     year: 2017,
   },
+  { id: 4, name: 'Slayyyter', deleted: false, year: 2019 },
+  { id: 5, name: 'Troubled Paradise', deleted: false, year: 2021 },
 ];
 
 const dataWithTag = [
@@ -127,13 +129,19 @@ const columnsWithWidth = [
     key: 'id',
     label: 'Código',
     sort: true,
-    width: 30,
+    width: 25,
   },
   {
     key: 'name',
     label: 'Nome',
     sort: false,
     width: 50,
+  },
+  {
+    key: 'year',
+    label: 'Ano',
+    sort: true,
+    width: 25,
   },
 ];
 

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -31,6 +31,17 @@ const data = [
   { id: 2, name: 'One More Light', deleted: false, year: 2017 },
 ];
 
+const longData = [
+  { id: 1, name: 'Meteora', deleted: false, year: 2003 },
+  { id: 2, name: 'One More Light', deleted: false, year: 2017 },
+  {
+    id: 3,
+    name: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Vero, voluptatibus veniam reiciendis repellendus laborum nam laboriosam est natus ut, delectus iure quis consequuntur eligendi aspernatur, corporis voluptates nulla assumenda adipisci. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Vero, voluptatibus veniam reiciendis repellendus laborum nam laboriosam est natus ut, delectus iure quis consequuntur eligendi aspernatur, corporis voluptates nulla assumenda adipisci. Lorem ipsum dolor, sit amet consectetur adipisicing elit. Vero, voluptatibus veniam reiciendis repellendus laborum nam laboriosam est natus ut, delectus iure quis consequuntur eligendi aspernatur, corporis voluptates nulla assumenda adipisci.',
+    deleted: false,
+    year: 2017,
+  },
+];
+
 const dataWithTag = [
   ...data,
   {
@@ -111,6 +122,21 @@ const withTagByRowColumns = [
   },
 ];
 
+const columnsWithWidth = [
+  {
+    key: 'id',
+    label: 'Código',
+    sort: true,
+    width: 30,
+  },
+  {
+    key: 'name',
+    label: 'Nome',
+    sort: false,
+    width: 50,
+  },
+];
+
 const actions = [
   {
     label: 'Excluir',
@@ -177,7 +203,8 @@ function returnTableConfig(
   paginationTotal,
   debounceOnSort = 0,
   pageSizeOptions = LIST_OF_PAGE_OPTIONS,
-  tooltipConfig?
+  tooltipConfig?,
+  hideLongData?
 ): { config: ConfigSmartTable<SafeAny> } {
   return {
     config: {
@@ -191,6 +218,7 @@ function returnTableConfig(
       },
       debounceOnSort,
       tooltipConfig: tooltipConfig,
+      hideLongData: hideLongData,
     },
   };
 }
@@ -302,7 +330,7 @@ TableCustomRow.parameters = {
       story: `Passos para customizar a linha da tabela.
     1. No HTML do seu componente, crie um ng-template com a diretiva 'let-row' e realize as customizações desejadas.
     A diretiva 'let-row' permite acessar os dados da linha através da identificação do objeto passado na configuração
-    da tabela. Veja o exemplo abaixo: 
+    da tabela. Veja o exemplo abaixo:
 
     <ng-template #customTemplate let-row>
       <td>{{row.id}}</td>
@@ -318,20 +346,20 @@ TableCustomRow.parameters = {
     </ng-template>
 
     2. No arquivo .ts do seu componente, utilize o decorator '@ViewChild' para obter a referência do template customizado
-    criado no arquivo HTML.  
-        
+    criado no arquivo HTML.
+
     export class AppComponent implements OnInit {
       @ViewChild("customTemplate", { static: true })
       customTemplate: TemplateRef<HTMLElement>;
 
       ...
     }
-      
+
     3. Passe a referência do template customizado para o atributo customRowTemplate da configuração da tabela.
 
     export class AppComponent implements OnInit {
       ...
-      
+
       ngOnInit(): void {
         this.config = {
           data,
@@ -344,3 +372,15 @@ TableCustomRow.parameters = {
     },
   },
 };
+
+export const WithEllipsisOnCell = Template.bind({});
+WithEllipsisOnCell.args = returnTableConfig(
+  longData,
+  columnsWithWidth,
+  actions,
+  2,
+  2000,
+  [10, 15, 30, 50, 100],
+  mockTooltip,
+  true
+);


### PR DESCRIPTION
## Issue Number

fix #767 

## Description

Added a config property on the smart table to allow the user to compress cell data and show a tooltip with is full content.

## Proposed Changes

- Definition of a class that does the compressing and adds the ellipsis;
- definition of a property that holds the condition to add the previous defined class to the cell;
- addition of the tooltip to the table's cells that will only appear if the new property is true and the container has overflown content.
- implementation of tests in a new describe;

## How to Test

Run yarn test smart-table or check the specifc story: Smart Table > With Ellipsis On Cell

## Screenshots

![image](https://github.com/Brisanet/ion/assets/98463818/72a06503-f21f-476e-8b5f-10c2454310f0)

## View Storybook

[Storybook](https://62eab350a45bdb0a5818520e-ffypptiqzo.chromatic.com/)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.