### PR TITLE
feat: add tooltip to column name on ion table #737

### DIFF
--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -20,35 +20,24 @@
         >
           <div class="header-style">
             <span
+              [attr.data-testid]="'th-span-' + column.key"
               class="th-span"
               ionTooltip
-              [ionTooltipTitle]="
-                column.configTooltip ? column.configTooltip.ionTooltipTitle : ''
-              "
+              [ionTooltipTitle]="column.configTooltip?.ionTooltipTitle || ''"
               [ionTooltipPosition]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipPosition
-                  : 'topCenter'
+                column.configTooltip?.ionTooltipPosition || 'topCenter'
               "
               [ionTooltipArrowPointAtCenter]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipArrowPointAtCenter
-                  : true
+                column.configTooltip?.ionTooltipArrowPointAtCenter || true
               "
               [ionTooltipColorScheme]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipColorScheme
-                  : 'dark'
+                column.configTooltip?.ionTooltipColorScheme || 'dark'
               "
               [ionTooltipTrigger]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipTrigger
-                  : 'hover'
+                column.configTooltip?.ionTooltipTrigger || 'hover'
               "
               [ionTooltipShowDelay]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipShowDelay
-                  : 0
+                column.configTooltip?.ionTooltipShowDelay || 0
               "
               [ionTooltipTemplateRef]="ionTooltipColumnTemplateBody"
             >

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -19,7 +19,32 @@
           [ngStyle]="{ width: column.width + '%' }"
         >
           <div class="header-style">
-            <span class="th-span">{{ column.label }}</span>
+            <ng-container *ngIf="column.configTooltip; else noTooltip">
+              <span
+                class="th-span"
+                ionTooltip
+                [ionTooltipTitle]="
+                  column.configTooltip.ionTooltipTitle || column.label
+                "
+                [ionTooltipPosition]="column.configTooltip.ionTooltipPosition"
+                [ionTooltipArrowPointAtCenter]="
+                  column.configTooltip.ionTooltipArrowPointAtCenter
+                "
+                [ionTooltipColorScheme]="
+                  column.configTooltip.ionTooltipColorScheme
+                "
+                [ionTooltipTrigger]="column.configTooltip.ionTooltipTrigger"
+                [ionTooltipShowDelay]="column.configTooltip.ionTooltipShowDelay"
+                [ionTooltipTemplateRef]="ionTooltipColumnTemplateBody"
+              >
+                {{ column.label }}
+              </span>
+            </ng-container>
+
+            <ng-template #noTooltip>
+              <span class="th-span">{{ column.label }}</span>
+            </ng-template>
+
             <button
               class="svg"
               (click)="
@@ -214,10 +239,6 @@
     </tbody>
   </table>
 
-  <ng-template #ionTooltipTemplateBody>
-    <ng-container [ngTemplateOutlet]="ionTooltipTemplate"></ng-container>
-  </ng-template>
-
   <div *ngIf="config.data && config.data.length === 0" class="noData">
     <ion-spinner
       *ngIf="config.loading; else noData"
@@ -265,5 +286,9 @@
 </div>
 
 <ng-template #ionTooltipTemplateBody>
+  <ng-container [ngTemplateOutlet]="ionTooltipTemplate"></ng-container>
+</ng-template>
+
+<ng-template #ionTooltipColumnTemplateBody>
   <ng-container [ngTemplateOutlet]="ionTooltipTemplate"></ng-container>
 </ng-template>

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -19,31 +19,41 @@
           [ngStyle]="{ width: column.width + '%' }"
         >
           <div class="header-style">
-            <ng-container *ngIf="column.configTooltip; else noTooltip">
-              <span
-                class="th-span"
-                ionTooltip
-                [ionTooltipTitle]="
-                  column.configTooltip.ionTooltipTitle || column.label
-                "
-                [ionTooltipPosition]="column.configTooltip.ionTooltipPosition"
-                [ionTooltipArrowPointAtCenter]="
-                  column.configTooltip.ionTooltipArrowPointAtCenter
-                "
-                [ionTooltipColorScheme]="
-                  column.configTooltip.ionTooltipColorScheme
-                "
-                [ionTooltipTrigger]="column.configTooltip.ionTooltipTrigger"
-                [ionTooltipShowDelay]="column.configTooltip.ionTooltipShowDelay"
-                [ionTooltipTemplateRef]="ionTooltipColumnTemplateBody"
-              >
-                {{ column.label }}
-              </span>
-            </ng-container>
-
-            <ng-template #noTooltip>
-              <span class="th-span">{{ column.label }}</span>
-            </ng-template>
+            <span
+              class="th-span"
+              ionTooltip
+              [ionTooltipTitle]="
+                column.configTooltip ? column.configTooltip.ionTooltipTitle : ''
+              "
+              [ionTooltipPosition]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipPosition
+                  : 'topCenter'
+              "
+              [ionTooltipArrowPointAtCenter]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipArrowPointAtCenter
+                  : true
+              "
+              [ionTooltipColorScheme]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipColorScheme
+                  : 'dark'
+              "
+              [ionTooltipTrigger]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipTrigger
+                  : 'hover'
+              "
+              [ionTooltipShowDelay]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipShowDelay
+                  : 0
+              "
+              [ionTooltipTemplateRef]="ionTooltipColumnTemplateBody"
+            >
+              {{ column.label }}
+            </span>
 
             <button
               class="svg"
@@ -290,5 +300,5 @@
 </ng-template>
 
 <ng-template #ionTooltipColumnTemplateBody>
-  <ng-container [ngTemplateOutlet]="ionTooltipTemplate"></ng-container>
+  <ng-container [ngTemplateOutlet]="ionTooltipTemplateColumn"></ng-container>
 </ng-template>

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -34,22 +34,6 @@ const columns: Column[] = [
   },
 ];
 
-const columnsWithTooltip: Column[] = [
-  {
-    key: 'name',
-    label: 'Nome',
-    sort: true,
-  },
-  {
-    key: 'height',
-    label: 'Altura',
-    sort: true,
-    configTooltip: {
-      ionTooltipTitle: 'Eu sou um tooltip',
-    },
-  },
-];
-
 const pagination = {
   actual: 1,
   itemsPerPage: 10,
@@ -230,6 +214,22 @@ describe('IonSmartTableComponent', () => {
 });
 
 describe('Table > columns header with tooltip', () => {
+  const columnsWithTooltip: Column[] = [
+    {
+      key: 'name',
+      label: 'Nome',
+      sort: true,
+    },
+    {
+      key: 'height',
+      label: 'Altura',
+      sort: true,
+      configTooltip: {
+        ionTooltipTitle: 'Eu sou um tooltip',
+      },
+    },
+  ];
+
   const propsColumnWithTooltip: IonSmartTableProps<Character> = {
     config: {
       data,
@@ -245,6 +245,7 @@ describe('Table > columns header with tooltip', () => {
       emit: events,
     } as SafeAny,
   };
+
   beforeEach(async () => {
     await sut(propsColumnWithTooltip);
   });

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -1,20 +1,20 @@
-import { IonSmartTableProps } from './../core/types/smart-table';
-import { StatusType } from './../core/types/status';
 import { fireEvent, render, screen, within } from '@testing-library/angular';
-import userEvent from '@testing-library/user-event';
+
 import { IonButtonModule } from '../button/button.module';
 import { IonCheckboxModule } from '../checkbox/checkbox.module';
 import { TooltipPosition, TooltipProps, TooltipTrigger } from '../core/types';
 import { IonIconModule } from '../icon/icon.module';
 import { IonPaginationModule } from '../pagination/pagination.module';
 import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
+import { IonSpinnerModule } from '../spinner/spinner.module';
 import { ActionTable, Column, EventTable } from '../table/utilsTable';
 import { IonTagModule } from '../tag/tag.module';
+import { IonTooltipModule } from '../tooltip/tooltip.module';
 import { PipesModule } from '../utils/pipes/pipes.module';
 import { SafeAny } from '../utils/safe-any';
+import { IonSmartTableProps } from './../core/types/smart-table';
+import { StatusType } from './../core/types/status';
 import { IonSmartTableComponent } from './smart-table.component';
-import { IonTooltipModule } from '../tooltip/tooltip.module';
-import { IonSpinnerModule } from '../spinner/spinner.module';
 
 const disabledArrowColor = '#CED2DB';
 const enabledArrowColor = '#0858CE';
@@ -224,19 +224,20 @@ describe('IonSmartTableComponent', () => {
 });
 
 describe('Table > columns header with tooltip', () => {
+  let columnHead: HTMLElement;
   const columnsWithTooltip: Column[] = [
     {
       key: 'name',
       label: 'Nome',
       sort: true,
+      configTooltip: {
+        ionTooltipTitle: 'Eu sou um tooltip',
+      },
     },
     {
       key: 'height',
       label: 'Altura',
       sort: true,
-      configTooltip: {
-        ionTooltipTitle: 'Eu sou um tooltip',
-      },
     },
   ];
 
@@ -260,13 +261,19 @@ describe('Table > columns header with tooltip', () => {
     await sut(propsColumnWithTooltip);
   });
 
-  it.skip('should render tooltip when it have a configTooltip', async () => {
-    await userEvent.hover(screen.getByText(columnsWithTooltip[1].label));
-    expect(await screen.findByTestId('ion-tooltip')).toBeInTheDocument();
+  afterEach(() => {
+    fireEvent.mouseLeave(columnHead);
   });
 
-  it('should not render tooltip when it doesnt have a configTooltip', async () => {
-    userEvent.hover(screen.getByText(columnsWithTooltip[0].label));
+  it('should render tooltip when it have a configTooltip', () => {
+    columnHead = screen.getByTestId('th-span-' + columnsWithTooltip[0].key);
+    fireEvent.mouseEnter(columnHead);
+    expect(screen.queryByTestId('ion-tooltip')).toBeInTheDocument();
+  });
+
+  it('should not render tooltip when it doesnt have a configTooltip', () => {
+    columnHead = screen.getByTestId('th-span-' + columnsWithTooltip[1].key);
+    fireEvent.mouseEnter(columnHead);
     expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
   });
 });

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -1,6 +1,7 @@
 import { IonSmartTableProps } from './../core/types/smart-table';
 import { StatusType } from './../core/types/status';
 import { fireEvent, render, screen, within } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import { IonButtonModule } from '../button/button.module';
 import { IonCheckboxModule } from '../checkbox/checkbox.module';
 import { TooltipPosition, TooltipProps, TooltipTrigger } from '../core/types';
@@ -30,6 +31,22 @@ const columns: Column[] = [
     key: 'height',
     label: 'Altura',
     sort: true,
+  },
+];
+
+const columnsWithTooltip: Column[] = [
+  {
+    key: 'name',
+    label: 'Nome',
+    sort: true,
+  },
+  {
+    key: 'height',
+    label: 'Altura',
+    sort: true,
+    configTooltip: {
+      ionTooltipTitle: 'Eu sou um tooltip',
+    },
   },
 ];
 
@@ -209,6 +226,37 @@ describe('IonSmartTableComponent', () => {
   afterEach(() => {
     defaultProps.config.data = JSON.parse(JSON.stringify(data));
     events.mockClear();
+  });
+});
+
+describe.skip('Table > columns with tooltip', () => {
+  const propsColumnWithTooltip: IonSmartTableProps<Character> = {
+    config: {
+      data,
+      columns: columnsWithTooltip,
+      pagination: {
+        total: 32,
+        itemsPerPage: 10,
+        page: 1,
+      },
+      loading: false,
+    },
+    events: {
+      emit: events,
+    } as SafeAny,
+  };
+  beforeEach(async () => {
+    await sut(propsColumnWithTooltip);
+  });
+
+  it('should not render tooltip when it doesnt have a configTooltip', async () => {
+    userEvent.hover(screen.getByText(columnsWithTooltip[0].label));
+    expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
+  });
+
+  it('should render tooltip when it have a configTooltip', async () => {
+    await userEvent.hover(screen.getByText(columnsWithTooltip[1].label));
+    expect(await screen.findByTestId('ion-tooltip')).toBeInTheDocument();
   });
 });
 

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -267,7 +267,7 @@ describe('Table > columns header with tooltip', () => {
   it('should render tooltip when it have a configTooltip', () => {
     columnHead = screen.getByTestId('th-span-' + columnsWithTooltip[0].key);
     fireEvent.mouseEnter(columnHead);
-    expect(screen.queryByTestId('ion-tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('ion-tooltip')).toBeVisible();
   });
 
   it('should not render tooltip when it doesnt have a configTooltip', () => {

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -229,7 +229,7 @@ describe('IonSmartTableComponent', () => {
   });
 });
 
-describe.skip('Table > columns with tooltip', () => {
+describe('Table > columns header with tooltip', () => {
   const propsColumnWithTooltip: IonSmartTableProps<Character> = {
     config: {
       data,
@@ -249,14 +249,14 @@ describe.skip('Table > columns with tooltip', () => {
     await sut(propsColumnWithTooltip);
   });
 
+  it.skip('should render tooltip when it have a configTooltip', async () => {
+    await userEvent.hover(screen.getByText(columnsWithTooltip[1].label));
+    expect(await screen.findByTestId('ion-tooltip')).toBeInTheDocument();
+  });
+
   it('should not render tooltip when it doesnt have a configTooltip', async () => {
     userEvent.hover(screen.getByText(columnsWithTooltip[0].label));
     expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
-  });
-
-  it('should render tooltip when it have a configTooltip', async () => {
-    await userEvent.hover(screen.getByText(columnsWithTooltip[1].label));
-    expect(await screen.findByTestId('ion-tooltip')).toBeInTheDocument();
   });
 });
 

--- a/projects/ion/src/lib/smart-table/smart-table.component.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.ts
@@ -35,6 +35,7 @@ const stateChange = {
 export class IonSmartTableComponent implements OnInit {
   @Input() config: ConfigSmartTable<SafeAny>;
   @Input() ionTooltipTemplate?: TemplateRef<void>;
+  @Input() ionTooltipTemplateColumn?: TemplateRef<void>;
   @Output() events = new EventEmitter<SmartTableEvent>();
 
   public mainCheckBoxState: CheckBoxStates = 'enabled';

--- a/projects/ion/src/lib/table/table.component.html
+++ b/projects/ion/src/lib/table/table.component.html
@@ -20,35 +20,24 @@
         >
           <div class="header-style">
             <span
+              [attr.data-testid]="'th-span-' + column.key"
               class="th-span"
               ionTooltip
-              [ionTooltipTitle]="
-                column.configTooltip ? column.configTooltip.ionTooltipTitle : ''
-              "
+              [ionTooltipTitle]="column.configTooltip?.ionTooltipTitle || ''"
               [ionTooltipPosition]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipPosition
-                  : 'topCenter'
+                column.configTooltip?.ionTooltipPosition || 'topCenter'
               "
               [ionTooltipArrowPointAtCenter]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipArrowPointAtCenter
-                  : true
+                column.configTooltip?.ionTooltipArrowPointAtCenter || true
               "
               [ionTooltipColorScheme]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipColorScheme
-                  : 'dark'
+                column.configTooltip?.ionTooltipColorScheme || 'dark'
               "
               [ionTooltipTrigger]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipTrigger
-                  : 'hover'
+                column.configTooltip?.ionTooltipTrigger || 'hover'
               "
               [ionTooltipShowDelay]="
-                column.configTooltip
-                  ? column.configTooltip.ionTooltipShowDelay
-                  : 0
+                column.configTooltip?.ionTooltipShowDelay || 0
               "
               [ionTooltipTemplateRef]="ionTooltipColumnTemplateBody"
             >

--- a/projects/ion/src/lib/table/table.component.html
+++ b/projects/ion/src/lib/table/table.component.html
@@ -19,7 +19,41 @@
           [ngStyle]="{ width: column.width + '%' }"
         >
           <div class="header-style">
-            <span class="th-span">{{ column.label }}</span>
+            <span
+              class="th-span"
+              ionTooltip
+              [ionTooltipTitle]="
+                column.configTooltip ? column.configTooltip.ionTooltipTitle : ''
+              "
+              [ionTooltipPosition]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipPosition
+                  : 'topCenter'
+              "
+              [ionTooltipArrowPointAtCenter]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipArrowPointAtCenter
+                  : true
+              "
+              [ionTooltipColorScheme]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipColorScheme
+                  : 'dark'
+              "
+              [ionTooltipTrigger]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipTrigger
+                  : 'hover'
+              "
+              [ionTooltipShowDelay]="
+                column.configTooltip
+                  ? column.configTooltip.ionTooltipShowDelay
+                  : 0
+              "
+              [ionTooltipTemplateRef]="ionTooltipColumnTemplateBody"
+            >
+              {{ column.label }}
+            </span>
             <button
               class="svg"
               [attr.data-testid]="'btn-sort-by-' + column.key"
@@ -179,3 +213,7 @@
     </div>
   </div>
 </div>
+
+<ng-template #ionTooltipColumnTemplateBody>
+  <ng-container [ngTemplateOutlet]="ionTooltipTemplateColumn"></ng-container>
+</ng-template>

--- a/projects/ion/src/lib/table/table.component.spec.ts
+++ b/projects/ion/src/lib/table/table.component.spec.ts
@@ -170,19 +170,20 @@ describe('IonTableComponent', () => {
 
 describe('Table > columns header with tooltip', () => {
   const events = jest.fn();
+  let columnHead: HTMLElement;
   const columnsWithTooltip: Column[] = [
     {
       key: 'name',
       label: 'Nome',
       sort: true,
+      configTooltip: {
+        ionTooltipTitle: 'Eu sou um tooltip',
+      },
     },
     {
       key: 'height',
       label: 'Altura',
       sort: true,
-      configTooltip: {
-        ionTooltipTitle: 'Eu sou um tooltip',
-      },
     },
   ];
 
@@ -206,13 +207,19 @@ describe('Table > columns header with tooltip', () => {
     await sut(propsColumnWithTooltip);
   });
 
-  it.skip('should render tooltip when it have a configTooltip', async () => {
-    await userEvent.hover(screen.getByText(columnsWithTooltip[1].label));
-    expect(await screen.findByTestId('ion-tooltip')).toBeInTheDocument();
+  afterEach(() => {
+    fireEvent.mouseLeave(columnHead);
   });
 
-  it('should not render tooltip when it doesnt have a configTooltip', async () => {
-    userEvent.hover(screen.getByText(columnsWithTooltip[0].label));
+  it('should render tooltip when it have a configTooltip', () => {
+    columnHead = screen.getByTestId('th-span-' + columnsWithTooltip[0].key);
+    fireEvent.mouseEnter(columnHead);
+    expect(screen.queryByTestId('ion-tooltip')).toBeInTheDocument();
+  });
+
+  it('should not render tooltip when it doesnt have a configTooltip', () => {
+    columnHead = screen.getByTestId('th-span-' + columnsWithTooltip[1].key);
+    fireEvent.mouseEnter(columnHead);
     expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
   });
 });

--- a/projects/ion/src/lib/table/table.component.spec.ts
+++ b/projects/ion/src/lib/table/table.component.spec.ts
@@ -213,7 +213,7 @@ describe('Table > columns header with tooltip', () => {
   it('should render tooltip when it have a configTooltip', () => {
     columnHead = screen.getByTestId('th-span-' + columnsWithTooltip[0].key);
     fireEvent.mouseEnter(columnHead);
-    expect(screen.queryByTestId('ion-tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('ion-tooltip')).toBeVisible();
   });
 
   it('should not render tooltip when it doesnt have a configTooltip', () => {

--- a/projects/ion/src/lib/table/table.component.spec.ts
+++ b/projects/ion/src/lib/table/table.component.spec.ts
@@ -1,6 +1,13 @@
-import { StatusType } from './../core/types/status';
+import {
+  AfterViewInit,
+  Component,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { fireEvent, render, screen, within } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
 import { IonButtonModule } from '../button/button.module';
 import { IonCheckboxModule } from '../checkbox/checkbox.module';
 import { IonTableProps } from '../core/types';
@@ -8,16 +15,12 @@ import { IonIconModule } from '../icon/icon.module';
 import { IonPaginationModule } from '../pagination/pagination.module';
 import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
 import { IonTagModule } from '../tag/tag.module';
+import { IonTooltipModule } from '../tooltip/tooltip.module';
 import { SafeAny } from '../utils/safe-any';
+import { StatusType } from './../core/types/status';
 import { IonTableComponent } from './table.component';
-import { ActionTable, Column, ColumnType, ConfigTable } from './utilsTable';
-import {
-  AfterViewInit,
-  Component,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core';
 import { IonTableModule } from './table.module';
+import { ActionTable, Column, ColumnType, ConfigTable } from './utilsTable';
 
 const disabledArrowColor = '#CED2DB';
 const enabledArrowColor = '#0858CE';
@@ -85,6 +88,7 @@ const sut = async (
       IonPaginationModule,
       IonTagModule,
       IonPopConfirmModule,
+      IonTooltipModule,
     ],
   });
 };
@@ -164,6 +168,55 @@ describe('IonTableComponent', () => {
   });
 });
 
+describe('Table > columns header with tooltip', () => {
+  const events = jest.fn();
+  const columnsWithTooltip: Column[] = [
+    {
+      key: 'name',
+      label: 'Nome',
+      sort: true,
+    },
+    {
+      key: 'height',
+      label: 'Altura',
+      sort: true,
+      configTooltip: {
+        ionTooltipTitle: 'Eu sou um tooltip',
+      },
+    },
+  ];
+
+  const propsColumnWithTooltip: IonTableProps<Disco> = {
+    config: {
+      data,
+      columns: columnsWithTooltip,
+      pagination: {
+        total: 32,
+        itemsPerPage: 10,
+        page: 1,
+      },
+      loading: false,
+    },
+    events: {
+      emit: events,
+    } as SafeAny,
+  };
+
+  beforeEach(async () => {
+    await sut(propsColumnWithTooltip);
+  });
+
+  it.skip('should render tooltip when it have a configTooltip', async () => {
+    await userEvent.hover(screen.getByText(columnsWithTooltip[1].label));
+    expect(await screen.findByTestId('ion-tooltip')).toBeInTheDocument();
+  });
+
+  it('should not render tooltip when it doesnt have a configTooltip', async () => {
+    userEvent.hover(screen.getByText(columnsWithTooltip[0].label));
+    expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();
+  });
+});
+
 describe('Table > Changes', () => {
   const propsToChange: IonTableProps<Disco> = {
     config: {
@@ -183,6 +236,7 @@ describe('Table > Changes', () => {
         IonPaginationModule,
         IonTagModule,
         IonPopConfirmModule,
+        IonTooltipModule,
       ],
     });
     const newData = [{ name: 'Meteora', deleted: false, id: 2 }];
@@ -203,6 +257,7 @@ describe('Table > Changes', () => {
         IonPaginationModule,
         IonTagModule,
         IonPopConfirmModule,
+        IonTooltipModule,
       ],
     });
     propsToChange.config.data = [];

--- a/projects/ion/src/lib/table/table.component.spec.ts
+++ b/projects/ion/src/lib/table/table.component.spec.ts
@@ -6,7 +6,6 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { fireEvent, render, screen, within } from '@testing-library/angular';
-import userEvent from '@testing-library/user-event';
 
 import { IonButtonModule } from '../button/button.module';
 import { IonCheckboxModule } from '../checkbox/checkbox.module';

--- a/projects/ion/src/lib/table/table.component.ts
+++ b/projects/ion/src/lib/table/table.component.ts
@@ -7,6 +7,7 @@ import {
   OnInit,
   Output,
   SimpleChanges,
+  TemplateRef,
 } from '@angular/core';
 import { CheckBoxStates } from '../core/types/checkbox';
 import { PageEvent } from '../core/types/pagination';
@@ -27,6 +28,7 @@ const stateChange = {
 })
 export class IonTableComponent implements OnInit, OnChanges {
   @Input() config: ConfigTable<SafeAny>;
+  @Input() ionTooltipTemplateColumn?: TemplateRef<void>;
   @Output() events = new EventEmitter<TableEvent>();
 
   public mainCheckBoxState: CheckBoxStates = 'enabled';

--- a/projects/ion/src/lib/table/table.module.ts
+++ b/projects/ion/src/lib/table/table.module.ts
@@ -7,6 +7,7 @@ import { IonButtonModule } from '../button/button.module';
 import { IonIconModule } from '../icon/icon.module';
 import { IonPaginationModule } from '../pagination/pagination.module';
 import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
+import { IonTooltipModule } from '../tooltip/tooltip.module';
 
 @NgModule({
   declarations: [IonTableComponent],
@@ -18,6 +19,7 @@ import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
     IonIconModule,
     IonPaginationModule,
     IonPopConfirmModule,
+    IonTooltipModule,
   ],
   exports: [IonTableComponent],
 })

--- a/projects/ion/src/lib/table/utilsTable.ts
+++ b/projects/ion/src/lib/table/utilsTable.ts
@@ -1,5 +1,5 @@
 import { TagStatus } from './../core/types/status';
-import { ConfigSmartTable, StatusType } from '../core/types';
+import { ConfigSmartTable, StatusType, TooltipProps } from '../core/types';
 import { SafeAny } from '../utils/safe-any';
 import { TemplateRef } from '@angular/core';
 
@@ -30,6 +30,7 @@ export interface Column {
   desc?: boolean;
   width?: number;
   actions?: ColumnActions;
+  configTooltip?: TooltipProps;
 }
 
 export interface ActionConfirm {

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -229,6 +229,38 @@ WithTagByColumn.args = returnTableConfig(
   2
 );
 
+const mockTooltipColumn = {
+  ionTooltipTitle: 'Eu sou um tooltip',
+  ionTooltipPosition: TooltipPosition.DEFAULT,
+  ionTooltipTrigger: TooltipTrigger.DEFAULT,
+  ionTooltipColorScheme: 'dark',
+  ionTooltipShowDelay: 1000,
+  ionTooltipArrowPointAtCenter: true,
+};
+
+const columnsWithTooltip = [
+  {
+    key: 'id',
+    label: 'Código',
+    sort: true,
+    configTooltip: { ...mockTooltipColumn },
+  },
+  {
+    key: 'name',
+    label: 'Nome',
+    sort: false,
+    configTooltip: { ...mockTooltipColumn },
+  },
+];
+
+export const ColumnWithTooltip = Template.bind({});
+ColumnWithTooltip.args = returnTableConfig(
+  data,
+  columnsWithTooltip,
+  actions,
+  2
+);
+
 export const WithTagByRow = Template.bind({});
 WithTagByRow.args = returnTableConfig(
   dataWithTag,
@@ -302,7 +334,7 @@ TableCustomRow.parameters = {
       story: `Passos para customizar a linha da tabela.
     1. No HTML do seu componente, crie um ng-template com a diretiva 'let-row' e realize as customizações desejadas.
     A diretiva 'let-row' permite acessar os dados da linha através da identificação do objeto passado na configuração
-    da tabela. Veja o exemplo abaixo: 
+    da tabela. Veja o exemplo abaixo:
 
     <ng-template #customTemplate let-row>
       <td>{{row.id}}</td>
@@ -318,20 +350,20 @@ TableCustomRow.parameters = {
     </ng-template>
 
     2. No arquivo .ts do seu componente, utilize o decorator '@ViewChild' para obter a referência do template customizado
-    criado no arquivo HTML.  
-        
+    criado no arquivo HTML.
+
     export class AppComponent implements OnInit {
       @ViewChild("customTemplate", { static: true })
       customTemplate: TemplateRef<HTMLElement>;
 
       ...
     }
-      
+
     3. Passe a referência do template customizado para o atributo customRowTemplate da configuração da tabela.
 
     export class AppComponent implements OnInit {
       ...
-      
+
       ngOnInit(): void {
         this.config = {
           data,

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -229,32 +229,23 @@ WithTagByColumn.args = returnTableConfig(
   2
 );
 
-const mockTooltipColumn = {
-  ionTooltipTitle: 'Eu sou um tooltip',
-  ionTooltipPosition: TooltipPosition.DEFAULT,
-  ionTooltipTrigger: TooltipTrigger.DEFAULT,
-  ionTooltipColorScheme: 'dark',
-  ionTooltipShowDelay: 1000,
-  ionTooltipArrowPointAtCenter: true,
-};
-
 const columnsWithTooltip = [
   {
     key: 'id',
     label: 'Código',
     sort: true,
-    configTooltip: { ...mockTooltipColumn },
+    configTooltip: { ...mockTooltip },
   },
   {
     key: 'name',
     label: 'Nome',
     sort: false,
-    configTooltip: { ...mockTooltipColumn },
+    configTooltip: { ...mockTooltip },
   },
 ];
 
-export const ColumnWithTooltip = Template.bind({});
-ColumnWithTooltip.args = returnTableConfig(
+export const ColumnHeaderWithTooltip = Template.bind({});
+ColumnHeaderWithTooltip.args = returnTableConfig(
   data,
   columnsWithTooltip,
   actions,

--- a/stories/Table.stories.ts
+++ b/stories/Table.stories.ts
@@ -1,7 +1,11 @@
 import { Meta, Story } from '@storybook/angular';
 import { IonTableComponent } from '../projects/ion/src/lib/table/table.component';
 import { SafeAny } from '../projects/ion/src/lib/utils/safe-any';
-import { IonTableModule } from '../projects/ion/src/public-api';
+import {
+  IonTableModule,
+  TooltipPosition,
+  TooltipTrigger,
+} from '../projects/ion/src/public-api';
 
 export default {
   title: 'Ion/Data Display/Table',
@@ -134,6 +138,30 @@ const actions = [
   },
 ];
 
+const mockTooltip = {
+  ionTooltipTitle: 'Eu sou um tooltip',
+  ionTooltipPosition: TooltipPosition.DEFAULT,
+  ionTooltipTrigger: TooltipTrigger.DEFAULT,
+  ionTooltipColorScheme: 'dark',
+  ionTooltipShowDelay: 1000,
+  ionTooltipArrowPointAtCenter: true,
+};
+
+const columnsWithTooltip = [
+  {
+    key: 'id',
+    label: 'Código',
+    sort: true,
+    configTooltip: { ...mockTooltip },
+  },
+  {
+    key: 'name',
+    label: 'Nome',
+    sort: false,
+    configTooltip: { ...mockTooltip },
+  },
+];
+
 export const Basic = Template.bind({});
 Basic.args = {
   config: {
@@ -195,6 +223,15 @@ WithTagByColumn.args = {
         },
       },
     ],
+  },
+};
+
+export const ColumnHeaderWithTooltip = Template.bind({});
+ColumnHeaderWithTooltip.args = {
+  config: {
+    data,
+    columns: columnsWithTooltip,
+    actions,
   },
 };
 


### PR DESCRIPTION
feat #737

Added tooltip setting for table column

[Gravação de tela de 2023-07-27 10-42-56.webm](https://github.com/Brisanet/ion/assets/93842972/67c29f02-9052-4425-8755-c8a4db451a42)

