### PR TITLE
fix: ion button click event on popconfirm and test adjusments

### DIFF
--- a/projects/ion/src/lib/popconfirm/popconfirm.component.html
+++ b/projects/ion/src/lib/popconfirm/popconfirm.component.html
@@ -22,14 +22,14 @@
     <div class="footer">
       <ion-button
         data-testid="pop-cancel-btn"
-        (click)="close()"
+        (ionOnClick)="close()"
         [label]="ionCancelText"
         type="ghost"
         size="sm"
       ></ion-button>
       <ion-button
         data-testid="pop-confirm-btn"
-        (click)="handleConfirm()"
+        (ionOnClick)="handleConfirm()"
         [label]="ionConfirmText"
         size="sm"
       ></ion-button>

--- a/projects/ion/src/lib/popconfirm/popconfirm.directive.spec.ts
+++ b/projects/ion/src/lib/popconfirm/popconfirm.directive.spec.ts
@@ -9,7 +9,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
-import { fireEvent, screen } from '@testing-library/angular';
+import { fireEvent, screen, within } from '@testing-library/angular';
 import { IonButtonModule } from '../button/button.module';
 import { IonDividerModule } from '../divider/divider.module';
 import { IonPopConfirmComponent } from './popconfirm.component';
@@ -179,7 +179,9 @@ describe('Directive: Popconfirm', () => {
 
   it('should click in confirm button', () => {
     directive.open();
-    fireEvent.click(screen.getByTestId('pop-confirm-btn'));
+    fireEvent.click(
+      within(screen.getByTestId('pop-confirm-btn')).getByRole('button')
+    );
     expect(screen.queryByTestId('pop-confirm-btn')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Issue Number

fix #786 

## Description

Change of the button click event listener to ionOnClick and test adjusments.

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.