### PR TITLE
refactor: fixing ion-radio click on label #782

### DIFF
--- a/projects/ion/src/lib/radio/radio.component.html
+++ b/projects/ion/src/lib/radio/radio.component.html
@@ -11,7 +11,7 @@
   />
   <label
     [ngClass]="{ labelDisabled: !disabled, 'labelDisabled-checked': disabled }"
-    [for]="label"
+    (click)="check()"
     >{{ label }}</label
   >
 </form>


### PR DESCRIPTION
## 782

fix #782 

## Description

This fixes the issue that was occurring when a function was passed to the ion-radio element and the user clicked on the radio label, the function was being called twice. Analyzing the error it was seen that the implementation of the "for" in the label was causing a problem known as "Event bubbling" in which the label was propagating the click to the input and executing it twice, causing duplicity.

## Proposed Changes

- Remove the "for" attribute from the label and pass the click function to it, to maintain the functionality

