### PR TITLE
fix: no data label margin reset

### DIFF
--- a/projects/ion/src/lib/no-data/no-data.component.scss
+++ b/projects/ion/src/lib/no-data/no-data.component.scss
@@ -13,6 +13,7 @@
     color: $neutral-6;
     font-family: 'Source Sans Pro';
     font-weight: 600;
+    margin: 0;
     @include font-size-xs;
   }
 }


### PR DESCRIPTION
## Descriptio

The no data component label was receiving a margin bottom by default when added to projects. It was needed to reset it in the component itself

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.