### PR TITLE
fix: indicator footer buttons render conditions

### DIFF
--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -48,7 +48,7 @@
         *ngIf="buttonConfig && !loading && !error"
       >
         <ion-button
-          *ngIf="buttonConfig.type !== 'popover'; else ionPopoverButton"
+          *ngIf="buttonConfig.type !== 'popover'"
           [attr.data-testid]="'ion-indicator-button-' + buttonConfig.type"
           type="ghost"
           size="sm"
@@ -57,28 +57,26 @@
           [iconType]="buttonConfig.icon ? buttonConfig.icon : 'right2'"
           (ionOnClick)="handleButtonClick(buttonConfig.type)"
         ></ion-button>
-        <ng-template #ionPopoverButton>
-          <ion-button
-            [attr.data-testid]="'ion-indicator-button-' + buttonConfig.type"
-            type="ghost"
-            size="sm"
-            rightSideIcon="true"
-            [label]="buttonConfig.label"
-            [iconType]="buttonConfig.icon ? buttonConfig.icon : 'right2'"
-            (ionOnClick)="handleButtonClick(buttonConfig.type)"
-            ionPopover
-            [ionPopoverTitle]="buttonConfig.popoverConfig.ionPopoverTitle"
-            [ionPopoverBody]="ionIndicatorPopoverBody"
-            [ionPopoverActions]="buttonConfig.popoverConfig.ionPopoverActions"
-            [ionPopoverIcon]="buttonConfig.popoverConfig.ionPopoverIcon"
-            [ionPopoverIconClose]="
-              buttonConfig.popoverConfig.ionPopoverIconClose
-            "
-            [ionPopoverPosition]="buttonConfig.popoverConfig.ionPopoverPosition"
-            (ionOnFirstAction)="buttonConfig.popoverConfig.firstAction()"
-            (ionOnSecondAction)="buttonConfig.popoverConfig.secondAction()"
-          ></ion-button>
-        </ng-template>
+
+        <ion-button
+          *ngIf="buttonConfig.popoverConfig"
+          [attr.data-testid]="'ion-indicator-button-' + buttonConfig.type"
+          type="ghost"
+          size="sm"
+          rightSideIcon="true"
+          [label]="buttonConfig.label"
+          [iconType]="buttonConfig.icon ? buttonConfig.icon : 'right2'"
+          (ionOnClick)="handleButtonClick(buttonConfig.type)"
+          ionPopover
+          [ionPopoverTitle]="buttonConfig.popoverConfig.ionPopoverTitle"
+          [ionPopoverBody]="ionIndicatorPopoverBody"
+          [ionPopoverActions]="buttonConfig.popoverConfig.ionPopoverActions"
+          [ionPopoverIcon]="buttonConfig.popoverConfig.ionPopoverIcon"
+          [ionPopoverIconClose]="buttonConfig.popoverConfig.ionPopoverIconClose"
+          [ionPopoverPosition]="buttonConfig.popoverConfig.ionPopoverPosition"
+          (ionOnFirstAction)="buttonConfig.popoverConfig.firstAction()"
+          (ionOnSecondAction)="buttonConfig.popoverConfig.secondAction()"
+        ></ion-button>
       </footer>
     </div>
   </div>


### PR DESCRIPTION
## Issue Number

fix #850 

## Proposed Changes

To achieve the validation necessary without changing the whole indicator types structure, only changes in the html were made.

- changed the logic in the indicator footer buttons;
- now it will render the open popover button only if the popover config is informed, not necessarily only depending of the button type.

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.