### PR TITLE
897 feat insert tooltip in tag cell on smart table

### DIFF
--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -81,7 +81,7 @@
       </tr>
     </thead>
 
-    <tbody>
+    <tbody data-testid="tbody">
       <ng-container
         *ngFor="let row of config.data; let index = index; let last = last"
       >
@@ -152,9 +152,14 @@
               }}</span>
               <ion-tag
                 *ngIf="column.type === 'tag'"
+                data-testid="tag-cell"
                 [label]="row[column.key]"
                 [status]="row[column.tag.statusKey] || column.tag.status"
                 [icon]="row[column.tag.iconKey] || column.tag.icon"
+                ionTooltip
+                [ionTooltipTitle]="
+                  row[column.tag.tooltipKey] || row[column.key]
+                "
               ></ion-tag>
             </td>
             <td *ngIf="config.actions">

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -6,7 +6,12 @@ import { IonIconModule } from '../icon/icon.module';
 import { IonPaginationModule } from '../pagination/pagination.module';
 import { IonPopConfirmModule } from '../popconfirm/popconfirm.module';
 import { IonSpinnerModule } from '../spinner/spinner.module';
-import { ActionTable, Column, EventTable } from '../table/utilsTable';
+import {
+  ActionTable,
+  Column,
+  ColumnType,
+  EventTable,
+} from '../table/utilsTable';
 import { IonTagModule } from '../tag/tag.module';
 import { IonTooltipModule } from '../tooltip/tooltip.module';
 import { PipesModule } from '../utils/pipes/pipes.module';
@@ -44,6 +49,7 @@ interface Character {
   mass: number;
   icon?: string;
   status?: StatusType;
+  tooltip?: string;
 }
 const data: Character[] = [
   {
@@ -59,6 +65,17 @@ const data: Character[] = [
     mass: 96,
     icon: 'technical',
     status: 'negative',
+  },
+];
+
+const singleData: Character[] = [
+  {
+    name: 'Luke Skywalker',
+    height: 172,
+    mass: 96,
+    icon: 'user',
+    status: 'success',
+    tooltip: 'Tooltip personalizado 1',
   },
 ];
 
@@ -604,8 +621,38 @@ describe('Table > Differents columns data type', () => {
       emit: eventSelect,
     } as SafeAny,
   };
+  const tableTagTooltip: IonSmartTableProps<Character> = {
+    config: {
+      columns: [
+        {
+          key: 'mass',
+          label: 'Mass',
+          type: ColumnType.TAG,
+          sort: false,
+          tag: {
+            icon: columnIcon,
+            status: columnStatus,
+          },
+        },
+      ],
+      data: JSON.parse(JSON.stringify(singleData)),
+      pagination: {
+        total: 1,
+        itemsPerPage: 10,
+        page: 1,
+      },
+    },
+  };
 
   describe('Tag', () => {
+    it('should show tooltip in tag cell', async () => {
+      await sut(tableTagTooltip);
+      fireEvent.mouseEnter(screen.getByTestId('tag-cell'));
+      expect(document.getElementsByTagName('ion-tooltip')).toHaveLength(1);
+      fireEvent.mouseLeave(screen.getByTestId('tag-cell'));
+      expect(document.getElementsByTagName('ion-tooltip')).toHaveLength(0);
+    });
+
     it('should show icon in tag by column icon', async () => {
       await sut(tableDifferentColumns);
       expect(

--- a/projects/ion/src/lib/table/utilsTable.ts
+++ b/projects/ion/src/lib/table/utilsTable.ts
@@ -21,6 +21,7 @@ interface TagRow {
   iconKey?: string;
   status?: TagStatus;
   statusKey?: string;
+  tooltipKey?: string;
 }
 export interface Column {
   label: string;

--- a/projects/ion/src/lib/tag/tag.component.scss
+++ b/projects/ion/src/lib/tag/tag.component.scss
@@ -12,6 +12,11 @@
   }
 }
 
+:host {
+  width: fit-content;
+  display: flex;
+}
+
 .ion-tag {
   display: flex;
   align-items: center;

--- a/stories/SmartTable.stories.ts
+++ b/stories/SmartTable.stories.ts
@@ -47,6 +47,7 @@ const dataWithTag = [
   {
     id: 3,
     name: 'Hybrid Theory',
+    tooltip: 'Tooltip personalizado 1',
     deleted: false,
     year: 2000,
     icon: 'star-solid',
@@ -55,6 +56,7 @@ const dataWithTag = [
   {
     id: 4,
     name: 'Minutes to Midnight',
+    tooltip: 'Tooltip personalizado 2',
     deleted: false,
     year: 2007,
     icon: 'union',
@@ -104,6 +106,7 @@ const withTagColumns = [
     tag: {
       icon: 'check',
       status: 'success',
+      tooltipKey: 'tooltip',
     },
   },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -16048,6 +16048,11 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==
+
 trim@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16048,11 +16048,6 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==
-
 trim@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"


### PR DESCRIPTION
## 897

Insert tooltipKey in tag cell on smart-table

feat #897 

## Proposed Changes

- insert tooltip key 

## How to Test

In columns of smart-table:
![image](https://github.com/Brisanet/ion/assets/138058056/f1f96529-3649-4413-b34c-d90bead23647)


## Screenshots

![image](https://github.com/Brisanet/ion/assets/138058056/cb47b57e-c916-417c-85e3-a1571555ec45)

## [View Storybook](https://62eab350a45bdb0a5818520e-meowywkpyt.chromatic.com/?path=/story/ion-data-display-smarttable--with-tag-by-column)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.