### PR TITLE
feat: disabled on ion-select

### DIFF
--- a/projects/ion/src/lib/core/types/select.ts
+++ b/projects/ion/src/lib/core/types/select.ts
@@ -12,6 +12,7 @@ export interface IonSelectProps {
   search?: EventEmitter<string>;
   required?: boolean;
   propLabel?: string;
+  disabled?: boolean;
 }
 
 export interface IonSelectItemProps {

--- a/projects/ion/src/lib/select/select.component.html
+++ b/projects/ion/src/lib/select/select.component.html
@@ -2,7 +2,8 @@
   class="ion-select"
   (click)="handleClick()"
   data-testid="ion-select"
-  [class.ion-select__required]="isValid"
+  [class.ion-select--required]="isValid"
+  [class.ion-select--disabled]="disabled"
 >
   <div class="ion-select-container">
     <ng-container *ngFor="let option of options; let i = index">
@@ -22,6 +23,7 @@
       [(ngModel)]="inputValue"
       (input)="onSearchChange()"
       [required]="required"
+      [disabled]="disabled"
     />
   </div>
   <div>

--- a/projects/ion/src/lib/select/select.component.scss
+++ b/projects/ion/src/lib/select/select.component.scss
@@ -66,12 +66,34 @@
     display: flex;
     margin-inline-end: 8px;
   }
-}
 
-.ion-select__required {
-  border-color: $negative-color;
-
-  &:hover {
+  &--required {
     border-color: $negative-color;
+
+    &:hover {
+      border-color: $negative-color;
+    }
+  }
+
+  &--disabled {
+    background-color: $neutral-2;
+    border-color: $neutral-4;
+    cursor: not-allowed;
+
+    &:hover {
+      border-color: $neutral-4;
+    }
+
+    input {
+      cursor: not-allowed;
+
+      &::placeholder {
+        color: $neutral-4;
+      }
+    }
+
+    ::ng-deep svg {
+      fill: $neutral-5;
+    }
   }
 }

--- a/projects/ion/src/lib/select/select.component.spec.ts
+++ b/projects/ion/src/lib/select/select.component.spec.ts
@@ -70,6 +70,25 @@ describe('IonSelecComponent - mode: default', () => {
     fireEvent.click(await getOption(options[0].key));
     expect(await screen.queryByTestId('ion-select-item-selected-0')).toBeNull();
   });
+
+  it('should be disabled when informed', async () => {
+    await sut({
+      options: getCopyOptions(),
+      disabled: true,
+    });
+    const selectInput = getIonSelectInput();
+
+    expect(selectInput).toBeDisabled();
+  });
+  it('should not open the dropdown when disabled', async () => {
+    await sut({
+      options: getCopyOptions(),
+      disabled: true,
+    });
+
+    fireEvent.click(getIonSelect());
+    expect(screen.queryByTestId('ion-dropdown')).not.toBeInTheDocument();
+  });
 });
 
 describe('IonSelecComponent - mode: multiple', () => {
@@ -137,7 +156,7 @@ describe('IonSelecComponent - mode: multiple', () => {
       await userEvent.click(select);
       userEvent.dblClick(document.body);
 
-      expect(select).toHaveClass('ion-select__required');
+      expect(select).toHaveClass('ion-select--required');
     });
     it('should not apply the required class if the parameter is false', async () => {
       await sut({
@@ -148,7 +167,7 @@ describe('IonSelecComponent - mode: multiple', () => {
       userEvent.click(select);
       userEvent.dblClick(document.body);
 
-      expect(select).not.toHaveClass('ion-select__required');
+      expect(select).not.toHaveClass('ion-select--required');
     });
     it('should not apply required class in multiple mode with an option checked', async () => {
       await sut({
@@ -167,7 +186,7 @@ describe('IonSelecComponent - mode: multiple', () => {
       userEvent.click(selectItem[0]);
       userEvent.dblClick(document.body);
 
-      expect(select).not.toHaveClass('ion-select__required');
+      expect(select).not.toHaveClass('ion-select--required');
     });
   });
 });

--- a/projects/ion/src/lib/select/select.component.ts
+++ b/projects/ion/src/lib/select/select.component.ts
@@ -22,6 +22,7 @@ export class IonSelectComponent implements OnInit {
   @Input() options: IonSelectProps['options'] = [];
   @Input() maxSelected?: IonSelectProps['maxSelected'];
   @Input() required: IonSelectProps['required'] = false;
+  @Input() disabled: IonSelectProps['disabled'] = false;
   @Input() propLabel: IonSelectProps['propLabel'] = 'label';
   @Output() events = new EventEmitter<IonSelectProps['options']>();
   @Output() search = new EventEmitter<string>();
@@ -38,6 +39,9 @@ export class IonSelectComponent implements OnInit {
   }
 
   handleClick(): void {
+    if (this.disabled) {
+      return;
+    }
     this.focusInput();
     this.showDropdown = !this.showDropdown;
   }

--- a/stories/Select.stories.ts
+++ b/stories/Select.stories.ts
@@ -74,6 +74,13 @@ Required.args = {
   required: true,
 };
 
+export const Disabled = Template.bind({});
+Disabled.args = {
+  options: fruitOptions,
+  placeholder: 'Select 3 fruits',
+  disabled: true,
+};
+
 export const CustomLabel = Template.bind({});
 CustomLabel.args = {
   options: [


### PR DESCRIPTION
## Issue Number

fix #905 

## Proposed Changes

- Added the disabled atribute to the input on the select;
- created a class with the disabled modifier;
- changed the required class name to follow BEM;

## How to Test

yarn test select

## Screenshots

![image](https://github.com/Brisanet/ion/assets/138060158/0e3bd1b1-1617-472f-a525-9d0e3910bf05)

## View Storybook

Provide a link to the chromatic Storybook that shows the proposed changes so reviewers can easily see the changes in action.

Please also be aware that in addition to the Chromatic link, the link in the pull request description will also need to be updated whenever changes are made.

<details>
  <summary>How can I access the Chromatic link?</summary>

- Open the pull request that you wish to verify the Storybook Chromatic on.

- At the bottom of the "Checks" comment, click on "Details" next to the "Chromatic/chromatic-deployment" status.

- On the "Checks" page, you will see a list of checks. Select the "Publish to Chromatic" section.

- Scroll down until you find the section "View your Storybook at https://examplelink", that represents the desired link.

</details>

## Compliance

- [ ] I have verified that this change complies with our code and contribution policies.
- [ ] I have verified that this change does not cause regressions and does not affect other parts of the code.