### PR TITLE
fix: tooltip zindex

### DIFF
--- a/projects/ion/src/lib/tooltip/tooltip.component.scss
+++ b/projects/ion/src/lib/tooltip/tooltip.component.scss
@@ -28,7 +28,7 @@ $arrow-size: 4.2px;
 }
 
 .ion-tooltip {
-  z-index: $zIndexLow;
+  z-index: $zIndexMid;
   position: fixed;
   padding: spacing(1);
   overflow-wrap: break-word;


### PR DESCRIPTION
## Issue Number

fix #928 

## Description

Change on the tooltip index so it wont be behind elements with high zindexes

## Proposed Changes

- Chaged its zindex from low to mid.

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.
