### PR TITLE
refactor: fixing style error occurring in certain chip flows #926

### DIFF
--- a/projects/ion/src/lib/chip-group/chip-group.component.html
+++ b/projects/ion/src/lib/chip-group/chip-group.component.html
@@ -14,6 +14,7 @@
     [iconPosition]="chip.iconPosition || iconPosition"
     [rightBadge]="chip.rightBadge || rightBadge"
     (click)="selectChip(chip)"
+    (events)="chipEvents($event)"
     (dropdownEvents)="dropdownEvents($event)"
     [attr.data-testid]="'chip-group-' + chip.label"
     [chipGroup]="true"

--- a/projects/ion/src/lib/chip-group/chip-group.component.html
+++ b/projects/ion/src/lib/chip-group/chip-group.component.html
@@ -6,7 +6,7 @@
     [disabled]="chip.disabled || disabled"
     [selected]="chip.selected"
     [showDropdown]="chip.selected && chip.options"
-    [showToggle]="true"
+    [showToggle]="chip.options"
     [size]="chip.size || size"
     [options]="chip.options"
     [icon]="chip.icon"

--- a/projects/ion/src/lib/chip-group/chip-group.component.html
+++ b/projects/ion/src/lib/chip-group/chip-group.component.html
@@ -6,6 +6,7 @@
     [disabled]="chip.disabled || disabled"
     [selected]="chip.selected"
     [showDropdown]="chip.selected && chip.options"
+    [showToggle]="true"
     [size]="chip.size || size"
     [options]="chip.options"
     [icon]="chip.icon"

--- a/projects/ion/src/lib/chip-group/chip-group.component.spec.ts
+++ b/projects/ion/src/lib/chip-group/chip-group.component.spec.ts
@@ -130,6 +130,7 @@ describe('With Dropdown', () => {
   it('should selected an item when chip has dropdown', async () => {
     await sut();
     const option = mockChips[1].options[0].label;
+    fireEvent.click(screen.getByText(mockChips[1].label));
     fireEvent.click(screen.getByText(option));
     expect(screen.queryAllByText(option)).toHaveLength(1);
   });
@@ -151,5 +152,24 @@ describe('With Dropdown', () => {
     fireEvent.click(screen.getByText('Chip 1'));
     fireEvent.click(screen.getByText('item 1'));
     expect(screen.getByTestId('ion-dropdown')).toBeInTheDocument();
+  });
+
+  it('should reset chip style when clicked outside dropdown', async () => {
+    await sut({
+      chips: [
+        {
+          label: 'Chip 1',
+          selected: false,
+          options: [{ label: 'item 1' }, { label: 'item 2' }],
+          multiple: true,
+        },
+      ],
+      selected: {
+        emit: selectEvent,
+      } as SafeAny,
+    });
+    fireEvent.click(screen.getByText('Chip 1'));
+    fireEvent.click(document.body);
+    expect(screen.getByText('Chip 1')).not.toHaveClass('chip-selected');
   });
 });

--- a/projects/ion/src/lib/chip-group/chip-group.component.ts
+++ b/projects/ion/src/lib/chip-group/chip-group.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import {
+  ChipEvent,
   ChipSize,
   IconDirection,
   IonChipProps,
@@ -62,6 +63,12 @@ export class IonChipGroupComponent {
     const selectedChips = this.chips.filter((chip) => chip.selected);
     if (!selectedChips.length) {
       chipSelected.selected = true;
+    }
+  }
+
+  chipEvents(event: ChipEvent) {
+    if (event.closeDropdown) {
+      this.clearChips();
     }
   }
 

--- a/projects/ion/src/lib/chip-group/chip-group.component.ts
+++ b/projects/ion/src/lib/chip-group/chip-group.component.ts
@@ -66,7 +66,7 @@ export class IonChipGroupComponent {
     }
   }
 
-  chipEvents(event: ChipEvent) {
+  chipEvents(event: ChipEvent): void {
     if (event.closeDropdown) {
       this.clearChips();
     }

--- a/projects/ion/src/lib/chip/chip.component.spec.ts
+++ b/projects/ion/src/lib/chip/chip.component.spec.ts
@@ -253,6 +253,7 @@ describe('Check update label', () => {
 
 describe('With Multiple Dropdown', () => {
   const dropdownEvent = jest.fn();
+  const events = jest.fn();
   const options = [
     {
       label: 'Meteora',
@@ -272,6 +273,9 @@ describe('With Multiple Dropdown', () => {
       multiple: true,
       dropdownEvents: {
         emit: dropdownEvent,
+      } as SafeAny,
+      events: {
+        emit: events,
       } as SafeAny,
     });
   });
@@ -311,6 +315,22 @@ describe('With Multiple Dropdown', () => {
     fireEvent.click(screen.getByText(options[0].label));
     fireEvent.click(screen.getByText('Limpar'));
     expect(dropdownEvent).toBeCalledWith([]);
+  });
+
+  it('should reset chip style when dropdown is closed', async () => {
+    fireEvent.click(screen.getByText('dropdown'));
+    fireEvent.click(document.body);
+    expect(screen.getByText('dropdown')).not.toHaveClass('chip-selected');
+  });
+
+  it('should emit event when dropdown is closed', async () => {
+    fireEvent.click(screen.getByText('dropdown'));
+    fireEvent.click(document.body);
+    expect(events).toBeCalledWith({
+      selected: false,
+      disabled: false,
+      closeDropdown: true,
+    });
   });
 
   afterEach(() => {

--- a/projects/ion/src/lib/chip/chip.component.ts
+++ b/projects/ion/src/lib/chip/chip.component.ts
@@ -21,6 +21,7 @@ export type IconDirection = 'right' | 'left';
 interface ChipEvent {
   selected: boolean;
   disabled: boolean;
+  closeDropdown?: boolean;
 }
 export interface IonChipProps {
   label: string;
@@ -207,6 +208,13 @@ export class ChipComponent implements OnInit, AfterViewInit, DoCheck {
   closeDropdown(): void {
     if (this.showDropdown) {
       this.showDropdown = false;
+      this.selected = false;
+
+      this.events.emit({
+        selected: this.selected,
+        disabled: this.disabled,
+        closeDropdown: true,
+      });
     }
   }
 

--- a/projects/ion/src/lib/core/types/chip.ts
+++ b/projects/ion/src/lib/core/types/chip.ts
@@ -18,6 +18,7 @@ export type ChipSize = 'sm' | 'md';
 export interface ChipEvent {
   selected: boolean;
   disabled: boolean;
+  closeDropdown?: boolean;
 }
 
 export interface IonChipProps {


### PR DESCRIPTION
## 926

fix #926 

## Description

Adding functionality so that when a chip has a dropdown and it is closed, the chip now loses its selected style. Fixed both on the chip and on the chip group

## Proposed Changes

- In the event of closing the dropdown, the process to remove the style (chip.component)
- Chip now emits, in its events, when the dropdown is closed. Change necessary to fix the problem in the chip-group3
- Chip-group now have the function to clear the chip selecteds when the dropdown-close event is emmited

## How to Test

Open the chip dropdown and then click outside the component