### PR TITLE
feat: add icon to dropdown option #945 :sparkles:

### DIFF
--- a/projects/ion/src/lib/core/types/dropdown.ts
+++ b/projects/ion/src/lib/core/types/dropdown.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from '@angular/core';
 import { IonInputProps } from './input';
 import { IonNoDataProps } from './no-data';
+import { IconType } from './icon';
 
 export interface DropdownItem {
   label: string;
@@ -8,6 +9,7 @@ export interface DropdownItem {
   selected?: boolean;
   disabled?: boolean;
   hovered?: boolean;
+  icon?: IconType;
 }
 
 export interface DropdownParams {

--- a/projects/ion/src/lib/dropdown/dropdown.component.html
+++ b/projects/ion/src/lib/dropdown/dropdown.component.html
@@ -42,7 +42,14 @@
       [id]="'option-' + index"
     >
       <div class="container">
-        <span>{{ option[propLabel] }}</span>
+        <div class="option-label">
+          <ion-icon
+            [type]="option.icon"
+            [size]="iconSize"
+            *ngIf="option.icon"
+          ></ion-icon>
+          {{ option[propLabel] }}
+        </div>
         <ion-icon
           [type]="option.hovered ? 'close' : 'check'"
           [attr.data-testid]="

--- a/projects/ion/src/lib/dropdown/dropdown.component.scss
+++ b/projects/ion/src/lib/dropdown/dropdown.component.scss
@@ -44,6 +44,7 @@
 
 .dropdown-item {
   @include dropdown-commons($neutral-7);
+  @include set-icon-color($neutral-7);
 
   &:hover {
     @include set-colors($primary-1, $neutral-7);

--- a/projects/ion/src/lib/dropdown/dropdown.component.scss
+++ b/projects/ion/src/lib/dropdown/dropdown.component.scss
@@ -51,6 +51,7 @@
 
   &:active {
     @include set-colors($primary-2, $primary-color);
+    @include set-icon-color($primary-color);
   }
 }
 
@@ -85,6 +86,15 @@
   align-items: center;
   justify-content: space-between;
   gap: spacing(1.5);
+}
+
+.option-label {
+  display: flex;
+  align-items: center;
+
+  ion-icon {
+    margin-right: spacing(1);
+  }
 }
 
 .content {

--- a/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
+++ b/projects/ion/src/lib/dropdown/dropdown.component.spec.ts
@@ -132,6 +132,20 @@ describe('IonDropdownComponent', () => {
     expect(screen.queryAllByTestId('ion-check-selected')).toHaveLength(1);
     expect(screen.queryAllByTestId('ion-close-selected')).toHaveLength(0);
   });
+
+  it('should show the option with icon', async () => {
+    const iconToShow = 'close';
+    const dropdownConfig: DropdownParams = {
+      ...defaultDropdown,
+      options: [
+        { label: 'Option 1', selected: false, icon: iconToShow },
+        { label: 'Option 2', selected: false },
+      ],
+    };
+
+    await sut(dropdownConfig);
+    expect(document.getElementById(`ion-icon-${iconToShow}`)).not.toBeNull();
+  });
 });
 
 describe('IonDropdownComponent / Disabled', () => {

--- a/stories/Dropdown.stories.ts
+++ b/stories/Dropdown.stories.ts
@@ -39,6 +39,15 @@ Basic.args = {
   options,
 };
 
+export const OptionWithIcon = Template.bind({});
+OptionWithIcon.args = {
+  options: [
+    { label: 'Encomendas', selected: false, icon: 'box' },
+    { label: 'Bancos', selected: false, icon: 'bank' },
+    { label: 'Conquistas', selected: false, icon: 'award' },
+  ],
+};
+
 export const NoData = Template.bind({});
 NoData.args = {
   options: [],


### PR DESCRIPTION
fix #945 

Now is possible add a icon in option

![image](https://github.com/Brisanet/ion/assets/6165180/1843a40f-b65e-4af7-9b77-e5d5e0e18f35)

look here! https://62eab350a45bdb0a5818520e-tkucgwrtdo.chromatic.com/?path=/story/ion-navigation-dropdown--option-with-icon
