### PR TITLE
fix: tooltip should not be visible when hovering a dropdown inside a button #876

### DIFF
--- a/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
@@ -1,13 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, Input, TemplateRef } from '@angular/core';
 import { fireEvent, render, screen } from '@testing-library/angular';
+
 import {
   TooltipColorScheme,
   TooltipPosition,
   TooltipTrigger,
 } from '../core/types';
-import { IonTooltipModule } from './tooltip.module';
 import { IonTooltipDirective } from './tooltip.directive';
+import { IonTooltipModule } from './tooltip.module';
 
 @Component({
   template: `
@@ -15,7 +16,7 @@ import { IonTooltipDirective } from './tooltip.directive';
       data-testid="hostTooltip"
       ionTooltip
       [ionTooltipTitle]="ionTooltipTitle"
-      [ionTooltipTemplateRef]="ref"
+      [ionTooltipTemplateRef]="ionTooltipTemplateRef ? ref : null"
       [ionTooltipColorScheme]="ionTooltipColorScheme"
       [ionTooltipPosition]="ionTooltipPosition"
       [ionTooltipTrigger]="ionTooltipTrigger"
@@ -29,11 +30,12 @@ import { IonTooltipDirective } from './tooltip.directive';
   `,
 })
 class HostTestComponent {
-  ionTooltipTitle = 'Tooltip';
-  ionTooltipColorScheme: TooltipColorScheme = 'dark';
-  ionTooltipPosition: TooltipPosition = TooltipPosition.DEFAULT;
-  ionTooltipTrigger: TooltipTrigger = TooltipTrigger.DEFAULT;
-  ionTooltipShowDelay = 0;
+  @Input() ionTooltipTitle = 'Tooltip';
+  @Input() ionTooltipColorScheme: TooltipColorScheme = 'dark';
+  @Input() ionTooltipPosition: TooltipPosition = TooltipPosition.DEFAULT;
+  @Input() ionTooltipTrigger: TooltipTrigger = TooltipTrigger.DEFAULT;
+  @Input() ionTooltipShowDelay = 0;
+  @Input() ionTooltipTemplateRef = true;
 }
 
 const sut = async (props: Partial<HostTestComponent> = {}): Promise<void> => {
@@ -75,9 +77,9 @@ describe('Directive: Tooltip', () => {
     expect(screen.getByText(ionTooltipTitle)).toBeInTheDocument();
   });
 
-  it('should not render tooltip when ionTooltipTitle is empty', async () => {
+  it('should not render tooltip when ionTooltipTitle our ionTooltipTemplateRef is empty', async () => {
     const ionTooltipTitle = '';
-    await sut({ ionTooltipTitle });
+    await sut({ ionTooltipTitle, ionTooltipTemplateRef: false });
 
     fireEvent.mouseEnter(screen.getByTestId('hostTooltip'));
     expect(screen.queryByTestId('ion-tooltip')).not.toBeInTheDocument();

--- a/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, TemplateRef } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { fireEvent, render, screen } from '@testing-library/angular';
 
 import {

--- a/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.spec.ts
@@ -77,7 +77,7 @@ describe('Directive: Tooltip', () => {
     expect(screen.getByText(ionTooltipTitle)).toBeInTheDocument();
   });
 
-  it('should not render tooltip when ionTooltipTitle our ionTooltipTemplateRef is empty', async () => {
+  it('should not render tooltip when ionTooltipTitle and ionTooltipTemplateRef is empty', async () => {
     const ionTooltipTitle = '';
     await sut({ ionTooltipTitle, ionTooltipTemplateRef: false });
 

--- a/projects/ion/src/lib/tooltip/tooltip.directive.ts
+++ b/projects/ion/src/lib/tooltip/tooltip.directive.ts
@@ -111,7 +111,7 @@ export class IonTooltipDirective implements OnDestroy, OnInit {
   }
 
   attachComponentToView(): void {
-    if (this.ionTooltipTitle) {
+    if (this.ionTooltipTitle || this.ionTooltipTemplateRef) {
       document.body.appendChild(this.createComponent());
       this.setComponentProperties();
     }
@@ -121,6 +121,13 @@ export class IonTooltipDirective implements OnDestroy, OnInit {
     if (!this.isComponentRefNull()) {
       this.componentRef.instance.ionTooltipVisible = true;
     }
+  }
+
+  shouldAttachComponent(): boolean {
+    const ionDropdownElement =
+      this.elementRef.nativeElement.querySelector('ion-dropdown');
+
+    return this.isComponentRefNull() && !ionDropdownElement;
   }
 
   destroyComponent(): void {
@@ -134,16 +141,16 @@ export class IonTooltipDirective implements OnDestroy, OnInit {
 
   @HostListener('mouseenter') onMouseEnter(): void {
     if (
-      this.isComponentRefNull() &&
+      this.shouldAttachComponent() &&
       this.isTooltipTrigger(TooltipTrigger.HOVER)
     ) {
       this.attachComponentToView();
     }
   }
 
-  @HostListener('click') onclick(): void {
+  @HostListener('click') onClick(): void {
     if (this.isTooltipTrigger(TooltipTrigger.CLICK)) {
-      this.isComponentRefNull()
+      this.shouldAttachComponent()
         ? this.attachComponentToView()
         : this.destroyComponent();
     } else {

--- a/stories/Tooltip.stories.ts
+++ b/stories/Tooltip.stories.ts
@@ -8,14 +8,14 @@ import {
 } from '../projects/ion/src/lib/core/types';
 import { IonTooltipComponent } from '../projects/ion/src/lib/tooltip/tooltip.component';
 import { IonTooltipDirective } from '../projects/ion/src/lib/tooltip/tooltip.directive';
-import { IonIconModule } from '../projects/ion/src/public-api';
+import { IonButtonModule, IonIconModule } from '../projects/ion/src/public-api';
 
 export default {
   title: 'Ion/Data Display/Tooltip',
   decorators: [
     moduleMetadata({
       declarations: [IonTooltipDirective, IonTooltipComponent],
-      imports: [CommonModule, IonIconModule],
+      imports: [CommonModule, IonIconModule, IonButtonModule],
       entryComponents: [IonTooltipComponent],
     }),
   ],
@@ -161,25 +161,15 @@ const WithTitleAndTemplateRef: Story = (args) => ({
         }
     </style>
     <div class="tooltip">
-      <span
-        ionTooltip
-        ionTooltipTitle="${args.ionTooltipTitle}"
-        [ionTooltipTemplateRef]="titleTemplate"
-        ionTooltipPosition="${args.ionTooltipPosition}"
-        [ionTooltipArrowPointAtCenter]="${args.ionTooltipArrowPointAtCenter}"
-        ionTooltipColorScheme="${args.ionTooltipColorScheme}"
-        ionTooltipTrigger="${args.ionTooltipTrigger}"
-        ionTooltipShowDelay="${args.ionTooltipShowDelay}"
-      >
-        Hover me
-      </span>
-      <ng-template #titleTemplate>
-        <div class="content">
-          <ion-icon type="wait" size="16" color="#FCFCFD"></ion-icon>
-          <span>Atualizado em 18/04/2022 às 16:34</span>
-        </div>
-      </ng-template>
+    <ion-button
+    label="click me"
+    [options]="[{ label: 'option 1' }, { label: 'option 2' }]"
+    showDropdown="true"
+    ionTooltip
+    ionTooltipTitle="sou um tooltipppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp"
+  ></ion-button>
     </div>
+
   `,
 });
 

--- a/stories/Tooltip.stories.ts
+++ b/stories/Tooltip.stories.ts
@@ -8,14 +8,14 @@ import {
 } from '../projects/ion/src/lib/core/types';
 import { IonTooltipComponent } from '../projects/ion/src/lib/tooltip/tooltip.component';
 import { IonTooltipDirective } from '../projects/ion/src/lib/tooltip/tooltip.directive';
-import { IonButtonModule, IonIconModule } from '../projects/ion/src/public-api';
+import { IonIconModule } from '../projects/ion/src/public-api';
 
 export default {
   title: 'Ion/Data Display/Tooltip',
   decorators: [
     moduleMetadata({
       declarations: [IonTooltipDirective, IonTooltipComponent],
-      imports: [CommonModule, IonIconModule, IonButtonModule],
+      imports: [CommonModule, IonIconModule],
       entryComponents: [IonTooltipComponent],
     }),
   ],
@@ -161,15 +161,25 @@ const WithTitleAndTemplateRef: Story = (args) => ({
         }
     </style>
     <div class="tooltip">
-    <ion-button
-    label="click me"
-    [options]="[{ label: 'option 1' }, { label: 'option 2' }]"
-    showDropdown="true"
-    ionTooltip
-    ionTooltipTitle="sou um tooltipppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp"
-  ></ion-button>
+      <span
+        ionTooltip
+        ionTooltipTitle="${args.ionTooltipTitle}"
+        [ionTooltipTemplateRef]="titleTemplate"
+        ionTooltipPosition="${args.ionTooltipPosition}"
+        [ionTooltipArrowPointAtCenter]="${args.ionTooltipArrowPointAtCenter}"
+        ionTooltipColorScheme="${args.ionTooltipColorScheme}"
+        ionTooltipTrigger="${args.ionTooltipTrigger}"
+        ionTooltipShowDelay="${args.ionTooltipShowDelay}"
+      >
+        Hover me
+      </span>
+      <ng-template #titleTemplate>
+        <div class="content">
+          <ion-icon type="wait" size="16" color="#FCFCFD"></ion-icon>
+          <span>Atualizado em 18/04/2022 às 16:34</span>
+        </div>
+      </ng-template>
     </div>
-
   `,
 });
 


### PR DESCRIPTION
#876

now when there is a dropdown open on the host element, the tooltip will not be rendered


[Gravação de tela de 2023-11-22 15-19-31.webm](https://github.com/Brisanet/ion/assets/138057813/2042978a-ab4b-4050-a60e-4629d931b721)
