### PR TITLE
fix: table cell word break

### DIFF
--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -99,7 +99,6 @@ table {
       font-weight: 400;
       line-height: 20px;
       color: $neutral-7;
-      word-break: break-all;
     }
 
     & input {


### PR DESCRIPTION
## Issue Number

fix #953 

## Description

Removed the word break css property so it could behave as expected.

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.