### PR TITLE
fix: table border radius

### DIFF
--- a/projects/ion/src/lib/table/table.component.scss
+++ b/projects/ion/src/lib/table/table.component.scss
@@ -33,6 +33,14 @@ table {
 
   & .border-header {
     border-bottom: 1px solid $neutral-4;
+
+    & th:first-child {
+      border-top-left-radius: $radius;
+    }
+
+    & th:last-child {
+      border-top-right-radius: $radius;
+    }
   }
 
   .svg {


### PR DESCRIPTION
## Issue Number

fix #960 

## Proposed Changes

- Added a border radius to thead's first and last th child elements.

## Screenshots

![image](https://github.com/Brisanet/ion/assets/138060158/59eba24b-2491-486e-9c4b-dc1428265379)

## View Storybook

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.