### PR TITLE
fix: siber closing when clicked in logo

### DIFF
--- a/projects/ion/src/lib/sidebar/sidebar.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar.component.html
@@ -5,7 +5,7 @@
 >
   <header class="ion-sidebar__header">
     <img
-      (click)="logoAction()"
+      (click)="handleLogoClick()"
       [class.ion-sidebar__logo--pointer]="!!logoAction"
       [src]="logo"
       alt="logo"

--- a/projects/ion/src/lib/sidebar/sidebar.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.component.ts
@@ -58,4 +58,14 @@ export class IonSidebarComponent {
     unselectAllItems(this.items);
     callItemAction(this.items, groupIndex);
   }
+
+  public handleLogoClick(): void {
+    if (this.logoAction) {
+      this.logoAction();
+    }
+
+    if (this.closeOnSelect) {
+      this.toggleSidebarVisibility();
+    }
+  }
 }

--- a/projects/ion/src/lib/sidebar/sidebar.spec.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.spec.ts
@@ -300,5 +300,9 @@ describe('Sidebar', () => {
       expect(itemGroup2).toHaveClass(selectedItemClass);
       expect(getByTestId('sidebar')).not.toHaveClass('ion-sidebar--opened');
     });
+    it('should close sidebar when logo is clicked', async () => {
+      userEvent.click(screen.getByRole('img'));
+      expect(getByTestId('sidebar')).not.toHaveClass('ion-sidebar--opened');
+    });
   });
 });


### PR DESCRIPTION
## Issue Number

fix #970 

## Description

Now the sidebar has the expected behavior. When clicked on the logo and the closeOnSelect property is true. The sidebar calls the logoAction and closes the sidebar.


## Screenshots
[Gravação de tela de 2023-12-01 11-36-14.webm](https://github.com/Brisanet/ion/assets/138057627/404f5843-dc56-4713-8789-6211284f60da)

## View Storybook

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
