### PR TITLE
feat: add second tooltip in indicator

### DIFF
--- a/projects/ion/src/lib/core/types/indicator.ts
+++ b/projects/ion/src/lib/core/types/indicator.ts
@@ -12,6 +12,7 @@ export enum IonIndicatorButtonType {
 export interface IonIndicatorProps {
   title?: string;
   tooltipText?: string;
+  secondTooltipText?: string;
   value?: string | number;
   secondValue?: string | number;
   buttonConfig?: IonIndicatorButtonConfiguration;

--- a/projects/ion/src/lib/core/types/indicator.ts
+++ b/projects/ion/src/lib/core/types/indicator.ts
@@ -12,7 +12,7 @@ export enum IonIndicatorButtonType {
 export interface IonIndicatorProps {
   title?: string;
   tooltipText?: string;
-  secondTooltipText?: string;
+  secondValueTooltipText?: string;
   value?: string | number;
   secondValue?: string | number;
   buttonConfig?: IonIndicatorButtonConfiguration;

--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -53,7 +53,7 @@
             ionTooltipPosition="bottomLeft"
             ionTooltipColorScheme="dark"
             ionTooltipTrigger="hover"
-            [ionTooltipTitle]="secondTooltipText"
+            [ionTooltipTitle]="secondValueTooltipText"
             [ionTooltipArrowPointAtCenter]="true"
           >
             {{ secondValue }}

--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -47,7 +47,17 @@
           *ngIf="!(value === null || value === undefined || value === '')"
         >
           <h4 data-testid="ion-indicator-value">{{ value }}</h4>
-          <p data-testid="ion-indicator-second-value">{{ secondValue }}</p>
+          <p
+            data-testid="ion-indicator-second-value"
+            ionTooltip
+            ionTooltipPosition="bottomLeft"
+            ionTooltipColorScheme="dark"
+            ionTooltipTrigger="hover"
+            [ionTooltipTitle]="secondTooltipText"
+            [ionTooltipArrowPointAtCenter]="true"
+          >
+            {{ secondValue }}
+          </p>
         </ng-container>
         <ng-container
           *ngIf="value === null || value === undefined || value === ''"

--- a/projects/ion/src/lib/indicator/indicator.component.spec.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.spec.ts
@@ -144,15 +144,15 @@ describe('IonIndicatorComponent', () => {
   });
 
   it('should render tooltip in secondValue when it is passed', async () => {
-    const secondTooltipText = 'testing ion indicator tooltip';
+    const secondValueTooltipText = 'testing ion indicator tooltip';
     await sut({
       value: 'abc',
       secondValue: 123,
-      secondTooltipText,
+      secondValueTooltipText,
     });
 
     userEvent.hover(getElementByTestId('secondValue'));
-    expect(screen.queryByText(secondTooltipText)).toBeInTheDocument();
+    expect(screen.queryByText(secondValueTooltipText)).toBeInTheDocument();
   });
 
   it('Should render footer and button emitter when receive buttonConfig with this type', async () => {

--- a/projects/ion/src/lib/indicator/indicator.component.spec.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.spec.ts
@@ -26,6 +26,7 @@ import {
 } from './mocks/indicator-button-config';
 import { IndicatorPopoverComponent } from './mocks/indicator-popover.component';
 import { IonAlertModule } from '../alert/alert.module';
+import userEvent from '@testing-library/user-event';
 
 @NgModule({
   entryComponents: [IonModalComponent, BodyMockComponent],
@@ -124,7 +125,9 @@ describe('IonIndicatorComponent', () => {
     await sut({ value: valueText, secondValue: secondText });
 
     expect(getElementByTestId('value').textContent).toBe(valueText);
-    expect(getElementByTestId('secondValue').textContent).toBe(secondText);
+    expect(getElementByTestId('secondValue').textContent.trim()).toBe(
+      secondText
+    );
   });
 
   it('Should render valueElement/secondValueElement when they receive number values', async () => {
@@ -135,9 +138,21 @@ describe('IonIndicatorComponent', () => {
     expect(getElementByTestId('value').textContent).toBe(
       valueNumber.toString()
     );
-    expect(getElementByTestId('secondValue').textContent).toBe(
+    expect(getElementByTestId('secondValue').textContent.trim()).toBe(
       secondValueNumber.toString()
     );
+  });
+
+  it('should render tooltip in secondValue when it is passed', async () => {
+    const secondTooltipText = 'testing ion indicator tooltip';
+    await sut({
+      value: 'abc',
+      secondValue: 123,
+      secondTooltipText,
+    });
+
+    userEvent.hover(getElementByTestId('secondValue'));
+    expect(screen.queryByText(secondTooltipText)).toBeInTheDocument();
   });
 
   it('Should render footer and button emitter when receive buttonConfig with this type', async () => {

--- a/projects/ion/src/lib/indicator/indicator.component.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.ts
@@ -21,6 +21,7 @@ import { IonModalService } from './../modal/modal.service';
 export class IonIndicatorComponent {
   @Input() title = 'Ion Indicator';
   @Input() tooltipText: string;
+  @Input() secondTooltipText: string;
   @Input() value: number | string;
   @Input() secondValue: number | string;
   @Input() buttonConfig: IonIndicatorButtonConfiguration;

--- a/projects/ion/src/lib/indicator/indicator.component.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.ts
@@ -21,7 +21,7 @@ import { IonModalService } from './../modal/modal.service';
 export class IonIndicatorComponent {
   @Input() title = 'Ion Indicator';
   @Input() tooltipText: string;
-  @Input() secondTooltipText: string;
+  @Input() secondValueTooltipText: string;
   @Input() value: number | string;
   @Input() secondValue: number | string;
   @Input() buttonConfig: IonIndicatorButtonConfiguration;

--- a/stories/Indicator.stories.ts
+++ b/stories/Indicator.stories.ts
@@ -44,7 +44,8 @@ WithTooltip.args = {
 export const WithSecondTooltip = Template.bind({});
 WithSecondTooltip.args = {
   title: 'Título do Indicator',
-  secondTooltipText: 'Texto personalizado via atributo secondTooltipText',
+  secondValueTooltipText:
+    'Texto personalizado via atributo secondValueTooltipText',
   value: 1500,
   secondValue: '5%',
 };

--- a/stories/Indicator.stories.ts
+++ b/stories/Indicator.stories.ts
@@ -41,6 +41,14 @@ WithTooltip.args = {
   secondValue: '5%',
 };
 
+export const WithSecondTooltip = Template.bind({});
+WithSecondTooltip.args = {
+  title: 'Título do Indicator',
+  secondTooltipText: 'Texto personalizado via atributo secondTooltipText',
+  value: 1500,
+  secondValue: '5%',
+};
+
 export const WithPreview = Template.bind({});
 WithPreview.args = {
   title: 'preview',


### PR DESCRIPTION
#987 

## Description

Pass text to create a tooltip on the second value of the indicator.

## Screenshots

![image](https://github.com/Brisanet/ion/assets/138119077/9249a0fc-bd50-4caa-b34b-d0270d5f5964)

## [View Storybook](https://62eab350a45bdb0a5818520e-yqszyuozdh.chromatic.com/?path=/story/ion-data-display-indicator--with-second-tooltip)


## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
