### PR TITLE
fix: return when disabled

### DIFF
--- a/projects/ion/src/lib/chip-group/chip-group.component.spec.ts
+++ b/projects/ion/src/lib/chip-group/chip-group.component.spec.ts
@@ -124,6 +124,22 @@ describe('ChipGroupComponent', () => {
     fireEvent.click(optionElement);
     expect(optionElement).toHaveAttribute('ng-reflect-selected', 'true');
   });
+
+  it('should not select a chip when disabled', async () => {
+    const chips = [
+      { label: 'Option 1', selected: false },
+      { label: 'Option 2', selected: false },
+    ];
+
+    await sut({
+      chips,
+      disabled: true,
+    });
+
+    const optionElement = screen.getByTestId(`chip-group-${chips[0].label}`);
+    fireEvent.click(optionElement);
+    expect(optionElement).not.toHaveClass('chip-selected');
+  });
 });
 
 describe('With Dropdown', () => {

--- a/projects/ion/src/lib/chip-group/chip-group.component.ts
+++ b/projects/ion/src/lib/chip-group/chip-group.component.ts
@@ -28,6 +28,9 @@ export class IonChipGroupComponent {
   @Output() dropdown? = new EventEmitter<DropdownItem[]>();
 
   selectChip(chipSelected: ChipInGroup): void {
+    if (this.disabled || chipSelected.disabled) {
+      return;
+    }
     const isChipSelectedOrMultiple =
       chipSelected.multiple && chipSelected.selected;
     if (isChipSelectedOrMultiple) {


### PR DESCRIPTION
## Issue Number

fix #998 

## Description

Since the chip-group has a internal logic to select the chip, was necessary to return early in the disabled cases.

## How to Test

yarn test chip-group

## View Storybook

[Story](https://62eab350a45bdb0a5818520e-bkjelofgvi.chromatic.com/?path=/story/ion-navigation-chipgroup--disable-default)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.