### PR TITLE
fix: modal service close #865

### DIFF
--- a/projects/ion/src/lib/modal/component/modal.component.ts
+++ b/projects/ion/src/lib/modal/component/modal.component.ts
@@ -14,6 +14,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 
+import { generateIDs } from '../../utils';
 import {
   IonModalConfiguration,
   IonModalResponse,
@@ -42,6 +43,7 @@ export class IonModalComponent implements OnInit, OnDestroy {
   private componentFactory: ComponentRef<unknown>;
   private _defaultModal: IonModalConfiguration = {
     title: 'Ion Modal',
+    id: generateIDs('modal-', 'modal'),
     width: this.DEFAULT_WIDTH,
     showOverlay: true,
     overlayCanDismiss: true,

--- a/projects/ion/src/lib/modal/modal.service.spec.ts
+++ b/projects/ion/src/lib/modal/modal.service.spec.ts
@@ -3,12 +3,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { fireEvent, screen } from '@testing-library/angular';
+
+import { IonAlertModule } from '../alert/alert.module';
 import { IonButtonModule } from '../button/button.module';
 import { IonModalComponent } from './component/modal.component';
 import { SelectMockComponent } from './mock/select-mock.component';
 import { IonModalService } from './modal.service';
 import { IonModalConfiguration } from './models/modal.interface';
-import { IonAlertModule } from '../alert/alert.module';
 
 describe('ModalService', () => {
   let fixture: ComponentFixture<ContainerRefTestComponent>;

--- a/projects/ion/src/lib/modal/modal.service.spec.ts
+++ b/projects/ion/src/lib/modal/modal.service.spec.ts
@@ -128,4 +128,38 @@ describe('ModalService', () => {
 
     expect(screen.getByTestId('modalTitle')).toHaveTextContent(newConfig.title);
   });
+
+  it('should close modal when call closeModal with id', () => {
+    jest.spyOn(modalService, 'closeModal');
+
+    modalService.open(SelectMockComponent, { id: 'modal' });
+    modalService.closeModal('modal');
+    fixture.detectChanges();
+
+    expect(modalService.closeModal).toHaveBeenCalled();
+  });
+
+  it('should close modals when call closeModal', () => {
+    jest.spyOn(modalService, 'closeModal');
+
+    modalService.open(SelectMockComponent, { id: 'modal-1' });
+    modalService.open(SelectMockComponent, { id: 'modal-2' });
+    modalService.closeModal();
+    expect(screen.getByTestId('modal')).toHaveAttribute('id', 'modal-1');
+    modalService.closeModal();
+    expect(modalService.closeModal).toHaveBeenCalledTimes(2);
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+
+  it(`should close modal when call closeModal with id and it's not the latest open`, () => {
+    jest.spyOn(modalService, 'closeModal');
+
+    modalService.open(SelectMockComponent, { id: 'modal-1' });
+    modalService.open(SelectMockComponent, { id: 'modal-2' });
+    modalService.closeModal('modal-1');
+    fixture.detectChanges();
+
+    expect(modalService.closeModal).toHaveBeenCalled();
+    expect(screen.getByTestId('modal')).toHaveAttribute('id', 'modal-2');
+  });
 });

--- a/projects/ion/src/lib/modal/modal.service.spec.ts
+++ b/projects/ion/src/lib/modal/modal.service.spec.ts
@@ -139,7 +139,7 @@ describe('ModalService', () => {
     expect(modalService.closeModal).toHaveBeenCalled();
   });
 
-  it('should close modals when call closeModal', () => {
+  it('should close two modals when call closeModal twice', () => {
     jest.spyOn(modalService, 'closeModal');
 
     modalService.open(SelectMockComponent, { id: 'modal-1' });

--- a/projects/ion/src/lib/modal/modal.service.spec.ts
+++ b/projects/ion/src/lib/modal/modal.service.spec.ts
@@ -142,8 +142,8 @@ describe('ModalService', () => {
   it('should close two modals when call closeModal twice', () => {
     jest.spyOn(modalService, 'closeModal');
 
-    modalService.open(SelectMockComponent, { id: 'modal-1' });
-    modalService.open(SelectMockComponent, { id: 'modal-2' });
+    modalService.open(SelectMockComponent);
+    modalService.open(SelectMockComponent);
     modalService.closeModal();
     expect(screen.getByTestId('modal')).toHaveAttribute('id', 'modal-1');
     modalService.closeModal();

--- a/projects/ion/src/lib/modal/modal.service.ts
+++ b/projects/ion/src/lib/modal/modal.service.ts
@@ -94,11 +94,11 @@ export class IonModalService {
 
   closeModal(id?: string): void {
     const modalComponentControl = id
-      ? this.findModalComponentRefById(id)
+      ? this.findModalControlById(id)
       : this.currentModalControl;
 
     if (modalComponentControl) {
-      this.closeModalComponentRef(modalComponentControl);
+      this.destroyModalControl(modalComponentControl);
     }
   }
 
@@ -109,21 +109,21 @@ export class IonModalService {
     });
   }
 
-  public findModalComponentRefById(id: string): ModalControl | undefined {
+  public findModalControlById(id: string): ModalControl | undefined {
     return this.modalsControls.find(
       (modal) => modal.ref.instance.configuration.id === id
     );
   }
 
-  private closeModalComponentRef(modalComponentControl: ModalControl): void {
-    this.appRef.detachView(modalComponentControl.ref.hostView);
-    modalComponentControl.subscriber.complete();
-    modalComponentControl.ref.destroy();
+  private destroyModalControl(modalControl: ModalControl): void {
+    this.appRef.detachView(modalControl.ref.hostView);
+    modalControl.subscriber.complete();
+    modalControl.ref.destroy();
 
     this.modalsControls = this.modalsControls.filter(
       (modal) =>
         modal.ref.instance.configuration.id !==
-        modalComponentControl.ref.instance.configuration.id
+        modalControl.ref.instance.configuration.id
     );
   }
 }

--- a/projects/ion/src/lib/modal/modal.service.ts
+++ b/projects/ion/src/lib/modal/modal.service.ts
@@ -10,7 +10,6 @@ import {
 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 
-import { generateIDs } from '../utils';
 import { SafeAny } from './../utils/safe-any';
 import { IonModalComponent } from './component/modal.component';
 import {
@@ -63,9 +62,6 @@ export class IonModalService {
     this.modalComponentControl.ref.instance.componentToBody = component;
     this.modalComponentControl.ref.instance.setDefaultConfig();
     if (configuration) {
-      if (!configuration.id) {
-        configuration.id = generateIDs('modal-', 'modal');
-      }
       this.modalComponentControl.ref.instance.setConfig(configuration);
     }
     this.appRef.attachView(this.modalComponentControl.ref.hostView);

--- a/projects/ion/src/lib/modal/modal.service.ts
+++ b/projects/ion/src/lib/modal/modal.service.ts
@@ -16,14 +16,27 @@ import {
   IonModalConfiguration,
   IonModalResponse,
 } from './models/modal.interface';
+import { generateIDs } from '../utils';
+
+interface ModalComponentRef {
+  ref: ComponentRef<IonModalComponent>;
+  subscriber: Subject<IonModalResponse | unknown>;
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class IonModalService {
   public readonly ionOnHeaderButtonAction = new Subject<SafeAny>();
-  private modalComponentRef!: ComponentRef<IonModalComponent>;
-  private componentSubscriber!: Subject<IonModalResponse | unknown>;
+  private modalsComponentRefs: ModalComponentRef[] = [];
+
+  private get modalComponentRef(): ModalComponentRef {
+    return this.modalsComponentRefs[this.modalsComponentRefs.length - 1];
+  }
+
+  private set modalComponentRef(ref: ModalComponentRef) {
+    this.modalsComponentRefs.push(ref);
+  }
 
   constructor(
     // TODO: SafeAny used due to an issue in Angular 8 (https://github.com/angular/angular/issues/20351). When projects are updated to v9, change "SafeAny" to "Document";
@@ -41,19 +54,25 @@ export class IonModalService {
       .resolveComponentFactory(IonModalComponent)
       .create(this.injector);
 
-    this.modalComponentRef = modal;
-    this.modalComponentRef.instance.componentToBody = component;
-    this.modalComponentRef.instance.setDefaultConfig();
+    this.modalComponentRef = {
+      ref: modal,
+      subscriber: new Subject<IonModalResponse | unknown>(),
+    };
+    this.modalComponentRef.ref.instance.componentToBody = component;
+    this.modalComponentRef.ref.instance.setDefaultConfig();
     if (configuration) {
-      this.modalComponentRef.instance.setConfig(configuration);
+      if (!configuration.id) {
+        configuration.id = generateIDs('modal-', 'modal');
+      }
+      this.modalComponentRef.ref.instance.setConfig(configuration);
     }
-    this.appRef.attachView(this.modalComponentRef.hostView);
-    this.modalComponentRef.changeDetectorRef.detectChanges();
+    this.appRef.attachView(this.modalComponentRef.ref.hostView);
+    this.modalComponentRef.ref.changeDetectorRef.detectChanges();
 
-    const modalElement = this.modalComponentRef.location.nativeElement;
+    const modalElement = this.modalComponentRef.ref.location.nativeElement;
     this.document.body.appendChild(modalElement);
 
-    this.modalComponentRef.instance.ionOnClose.subscribe(
+    this.modalComponentRef.ref.instance.ionOnClose.subscribe(
       (valueFromModal: IonModalResponse) => {
         if (!valueFromModal) {
           this.closeModal();
@@ -64,18 +83,17 @@ export class IonModalService {
       }
     );
 
-    this.modalComponentRef.instance.ionOnHeaderButtonAction.subscribe(
+    this.modalComponentRef.ref.instance.ionOnHeaderButtonAction.subscribe(
       (valueFromModal: IonModalResponse) => {
         this.emitHeaderAction(valueFromModal);
       }
     );
 
-    this.componentSubscriber = new Subject<IonModalResponse | unknown>();
-    return this.componentSubscriber.asObservable();
+    return this.modalComponentRef.subscriber.asObservable();
   }
 
   emitValueAndCloseModal(valueToEmit: IonModalResponse | unknown): void {
-    this.componentSubscriber.next(valueToEmit);
+    this.modalComponentRef.subscriber.next(valueToEmit);
     this.closeModal();
   }
 
@@ -83,18 +101,38 @@ export class IonModalService {
     this.ionOnHeaderButtonAction.next(valueToEmit);
   }
 
-  closeModal(): void {
-    if (this.modalComponentRef) {
-      this.appRef.detachView(this.modalComponentRef.hostView);
-      this.componentSubscriber.complete();
-      this.modalComponentRef.destroy();
+  closeModal(id?: string): void {
+    const modalComponentRef = id
+      ? this.findModalComponentRefById(id)
+      : this.modalComponentRef;
+
+    if (modalComponentRef) {
+      this.closeModalComponentRef(modalComponentRef);
     }
   }
 
   reconfigModal(configuration: IonModalConfiguration): void {
-    this.modalComponentRef.instance.setConfig({
-      ...this.modalComponentRef.instance.configuration,
+    this.modalComponentRef.ref.instance.setConfig({
+      ...this.modalComponentRef.ref.instance.configuration,
       ...configuration,
     });
+  }
+
+  private findModalComponentRefById(id: string): ModalComponentRef | undefined {
+    return this.modalsComponentRefs.find(
+      (modal) => modal.ref.instance.configuration.id === id
+    );
+  }
+
+  private closeModalComponentRef(modalComponentRef: ModalComponentRef): void {
+    this.appRef.detachView(modalComponentRef.ref.hostView);
+    modalComponentRef.subscriber.complete();
+    modalComponentRef.ref.destroy();
+
+    this.modalsComponentRefs = this.modalsComponentRefs.filter(
+      (modal) =>
+        modal.ref.instance.configuration.id !==
+        modalComponentRef.ref.instance.configuration.id
+    );
   }
 }

--- a/projects/ion/src/lib/modal/modal.service.ts
+++ b/projects/ion/src/lib/modal/modal.service.ts
@@ -28,7 +28,7 @@ interface ModalComponentRef {
 })
 export class IonModalService {
   public readonly ionOnHeaderButtonAction = new Subject<SafeAny>();
-  private modalsComponentRefs: ModalComponentRef[] = [];
+  public modalsComponentRefs: ModalComponentRef[] = [];
 
   private get modalComponentRef(): ModalComponentRef {
     return this.modalsComponentRefs[this.modalsComponentRefs.length - 1];

--- a/projects/ion/src/lib/modal/models/modal.interface.ts
+++ b/projects/ion/src/lib/modal/models/modal.interface.ts
@@ -1,5 +1,8 @@
+import { ComponentRef } from '@angular/core';
 import { IconType, IonAlertProps, IonButtonProps } from '../../core/types';
 import { SafeAny } from '../../utils/safe-any';
+import { IonModalComponent } from '../component/modal.component';
+import { Subject } from 'rxjs';
 
 export interface IonModalConfiguration {
   id?: string;
@@ -33,4 +36,9 @@ interface IonModalHeaderButton {
 
 export interface IonModalResponse {
   [key: string]: unknown;
+}
+
+export interface ModalControl {
+  ref: ComponentRef<IonModalComponent>;
+  subscriber: Subject<IonModalResponse | unknown>;
 }

--- a/projects/ion/src/lib/modal/models/modal.interface.ts
+++ b/projects/ion/src/lib/modal/models/modal.interface.ts
@@ -1,8 +1,9 @@
 import { ComponentRef } from '@angular/core';
+import { Subject } from 'rxjs';
+
 import { IconType, IonAlertProps, IonButtonProps } from '../../core/types';
 import { SafeAny } from '../../utils/safe-any';
 import { IonModalComponent } from '../component/modal.component';
-import { Subject } from 'rxjs';
 
 export interface IonModalConfiguration {
   id?: string;

--- a/projects/ion/src/lib/utils/datePicker.spec.ts
+++ b/projects/ion/src/lib/utils/datePicker.spec.ts
@@ -22,7 +22,7 @@ describe('DatePicker', () => {
       result = isToday(currentDate, lang);
       expect(result).toBe(true);
     });
-    
+
     it('should return false if day is not today', () => {
       currentDate = new Day(new Date('2024-01-03'));
       result = isToday(currentDate, lang);

--- a/projects/ion/src/lib/utils/generateID.spec.ts
+++ b/projects/ion/src/lib/utils/generateID.spec.ts
@@ -2,25 +2,25 @@ import { generateIDs } from './generateID';
 
 describe('generateIDs', () => {
   it('should return the prefix if no elements with the specified testid exist', () => {
-    const generetedID = generateIDs('prefix', 'testeid');
+    const generetedID = generateIDs('prefix', 'testid');
     expect(generetedID).toBe('prefix1');
   });
 
   it('should generate unique IDs with the specified prefix and testid', () => {
     document.body.innerHTML = `
-      <div data-testid="testeid" id="prefix1"></div>
-      <div data-testid="testeid" id="prefix2"></div>
+      <div data-testid="testid" id="prefix1"></div>
+      <div data-testid="testid" id="prefix2"></div>
     `;
 
-    const generetedID1 = generateIDs('prefix', 'testeid');
+    const generetedID1 = generateIDs('prefix', 'testid');
     expect(generetedID1).toBe('prefix3');
 
     const newDiv = document.createElement('div');
-    newDiv.setAttribute('data-testid', 'testeid');
+    newDiv.setAttribute('data-testid', 'testid');
     newDiv.setAttribute('id', generetedID1);
     document.body.appendChild(newDiv);
 
-    const generatedID2 = generateIDs('prefix', 'testeid');
+    const generatedID2 = generateIDs('prefix', 'testid');
     expect(generatedID2).toBe('prefix4');
   });
 });

--- a/projects/ion/src/lib/utils/generateID.ts
+++ b/projects/ion/src/lib/utils/generateID.ts
@@ -4,10 +4,10 @@ export const ID_SELECTOR = '#';
 
 export const COOLDOWN_TIME = 400;
 
-export const generateIDs = (prefix: string, testeid: string): string => {
+export const generateIDs = (prefix: string, testid: string): string => {
   let id = 1;
   const allElements = document.querySelectorAll(
-    '*[data-testid="' + testeid + '"]'
+    '*[data-testid="' + testid + '"]'
   );
   const arrayElements = Array.from(allElements);
   arrayElements.map((element) => {


### PR DESCRIPTION
#865

Previously, the modal service allowed only one reference, resulting in the replacement of the first modal when opening a second one. Now, with the refactoring, the service operates with an array of modals, preserving individual references. This prevents conflicts, enabling the simultaneous opening of multiple modals without losing control over each one. The update makes the service more flexible and adaptable to scenarios with multiple modals.

[Gravação de tela de 2024-01-23 11-31-19.webm](https://github.com/Brisanet/ion/assets/138057813/d470890b-0b80-4693-b7fe-0baa5e7553e7)
