### PR TITLE
1019 feat add a tooltip to indicator titles when necessary and header title icon

### DIFF
--- a/projects/ion/src/lib/core/types/indicator.ts
+++ b/projects/ion/src/lib/core/types/indicator.ts
@@ -1,6 +1,7 @@
 import { Type } from '@angular/core';
 import { IonModalConfiguration } from '../../modal/models/modal.interface';
 import { PopoverProps } from './popover';
+import { IonIconProps } from './icon';
 
 export enum IonIndicatorButtonType {
   Redirect = 'redirect',
@@ -11,6 +12,7 @@ export enum IonIndicatorButtonType {
 
 export interface IonIndicatorProps {
   title?: string;
+  headerTitleIconConfig?: IonIconProps;
   tooltipText?: string;
   secondValueTooltipText?: string;
   value?: string | number;

--- a/projects/ion/src/lib/core/types/indicator.ts
+++ b/projects/ion/src/lib/core/types/indicator.ts
@@ -12,7 +12,7 @@ export enum IonIndicatorButtonType {
 
 export interface IonIndicatorProps {
   title?: string;
-  headerTitleIconConfig?: Pick<IonIconProps, 'type' | 'color'>;
+  headerIcon?: Pick<IonIconProps, 'type' | 'color'>;
   tooltipText?: string;
   secondValueTooltipText?: string;
   value?: string | number;

--- a/projects/ion/src/lib/core/types/indicator.ts
+++ b/projects/ion/src/lib/core/types/indicator.ts
@@ -12,7 +12,7 @@ export enum IonIndicatorButtonType {
 
 export interface IonIndicatorProps {
   title?: string;
-  headerTitleIconConfig?: IonIconProps;
+  headerTitleIconConfig?: Pick<IonIconProps, 'type' | 'color'>;
   tooltipText?: string;
   secondValueTooltipText?: string;
   value?: string | number;

--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -8,6 +8,12 @@
   </div>
   <div *ngIf="!preview">
     <header class="title">
+      <ion-icon
+        *ngIf="headerTitleIconConfig"
+        [type]="headerTitleIconConfig.type"
+        [size]="headerTitleIconConfig.size || 16"
+        [color]="headerTitleIconConfig.color"
+      ></ion-icon>
       <h1
         data-testid="ion-indicator-title"
         ionTooltip

--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -9,10 +9,10 @@
   <div *ngIf="!preview">
     <header class="title">
       <ion-icon
-        *ngIf="headerTitleIconConfig"
-        [type]="headerTitleIconConfig.type"
+        *ngIf="headerIcon"
+        [type]="headerIcon.type"
         [size]="16"
-        [color]="headerTitleIconConfig.color || '#505566'"
+        [color]="headerIcon.color || '#505566'"
       ></ion-icon>
       <h1
         data-testid="ion-indicator-title"

--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -11,8 +11,8 @@
       <ion-icon
         *ngIf="headerTitleIconConfig"
         [type]="headerTitleIconConfig.type"
-        [size]="headerTitleIconConfig.size || 16"
-        [color]="headerTitleIconConfig.color"
+        [size]="16"
+        [color]="headerTitleIconConfig.color || '#505566'"
       ></ion-icon>
       <h1
         data-testid="ion-indicator-title"

--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -8,7 +8,16 @@
   </div>
   <div *ngIf="!preview">
     <header class="title">
-      <h1 data-testid="ion-indicator-title">{{ title }}</h1>
+      <h1
+        data-testid="ion-indicator-title"
+        ionTooltip
+        [ionTooltipTitle]="
+          indicatorTitle.offsetWidth < indicatorTitle.scrollWidth && title
+        "
+        #indicatorTitle
+      >
+        {{ title }}
+      </h1>
       <ion-icon
         data-testid="ion-indicator-tooltip"
         *ngIf="tooltipText"

--- a/projects/ion/src/lib/indicator/indicator.component.scss
+++ b/projects/ion/src/lib/indicator/indicator.component.scss
@@ -1,7 +1,7 @@
 @import '../../styles/index.scss';
 
 @mixin icon-style {
-  ion-icon {
+  ion-icon:not(:first-child) {
     ::ng-deep svg {
       fill: $neutral-6;
     }
@@ -34,6 +34,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: spacing(1);
     background: $neutral-2;
     padding: 8px 16px;
     height: 36px;
@@ -51,6 +52,7 @@
       font-weight: 600;
       font-size: 14px;
       max-width: 230px;
+      margin-right: auto;
 
       @extend .ellipsis-in-text;
     }

--- a/projects/ion/src/lib/indicator/indicator.component.spec.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.spec.ts
@@ -187,9 +187,8 @@ describe('IonIndicatorComponent', () => {
       tooltipText: 'Texto personalizado via atributo tooltipText',
       value: 1500,
       secondValue: '5%',
-      headerTitleIconConfig: {
+      headerIcon: {
         type: 'box',
-        color: '#FF0016',
       },
     });
 

--- a/projects/ion/src/lib/indicator/indicator.component.spec.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.spec.ts
@@ -168,7 +168,7 @@ describe('IonIndicatorComponent', () => {
     expect(screen.getByTestId('ion-tooltip')).toBeInTheDocument();
   });
 
-  it('shoul not render the header title icon when informed', async () => {
+  it('shoul not render the header title icon by default', async () => {
     await sut({
       title: 'Título personalizado via atributo title',
       tooltipText: 'Texto personalizado via atributo tooltipText',

--- a/projects/ion/src/lib/indicator/indicator.component.spec.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.spec.ts
@@ -98,7 +98,7 @@ describe('IonIndicatorComponent', () => {
     await sut();
     const defaultTitle = 'Ion Indicator';
     expect(screen.getByTestId('ion-indicator')).toBeInTheDocument();
-    expect(getElementByTestId('title').textContent).toBe(defaultTitle);
+    expect(getElementByTestId('title').textContent.trim()).toBe(defaultTitle);
     expect(screen.queryByTestId('ion-indicator-value')).toBeFalsy();
     expect(screen.queryByTestId('ion-indicator-second-value')).toBeFalsy();
     expect(getElementByTestId('tooltip')).not.toBeInTheDocument();
@@ -109,7 +109,7 @@ describe('IonIndicatorComponent', () => {
     const testTitle = 'testing ion indicator title';
     await sut({ title: testTitle });
 
-    expect(getElementByTestId('title').textContent).toBe(testTitle);
+    expect(getElementByTestId('title').textContent.trim()).toBe(testTitle);
   });
 
   it('Should render ion-icon when passed tooltipText', async () => {
@@ -153,6 +153,49 @@ describe('IonIndicatorComponent', () => {
 
     userEvent.hover(getElementByTestId('secondValue'));
     expect(screen.queryByText(secondValueTooltipText)).toBeInTheDocument();
+  });
+
+  it('should show a tooltip when it has a long title', async () => {
+    const longTitleSut = {
+      title:
+        'Título personalizado via atributo title via atributo titlevia atributo title',
+      value: 1500,
+      secondValue: '5%',
+    };
+    await sut(longTitleSut);
+
+    userEvent.hover(screen.getByTestId(elements.title));
+    expect(screen.getByTestId('ion-tooltip')).toBeInTheDocument();
+  });
+
+  it('shoul not render the header title icon when informed', async () => {
+    await sut({
+      title: 'Título personalizado via atributo title',
+      tooltipText: 'Texto personalizado via atributo tooltipText',
+      value: 1500,
+      secondValue: '5%',
+    });
+
+    const headerTitleIcon = document.getElementById('ion-icon-box');
+
+    expect(headerTitleIcon).not.toBeInTheDocument();
+  });
+
+  it('shoul render the header title icon when informed', async () => {
+    await sut({
+      title: 'Título personalizado via atributo title',
+      tooltipText: 'Texto personalizado via atributo tooltipText',
+      value: 1500,
+      secondValue: '5%',
+      headerTitleIconConfig: {
+        type: 'box',
+        color: '#FF0016',
+      },
+    });
+
+    const headerTitleIcon = document.getElementById('ion-icon-box');
+
+    expect(headerTitleIcon).toBeInTheDocument();
   });
 
   it('Should render footer and button emitter when receive buttonConfig with this type', async () => {

--- a/projects/ion/src/lib/indicator/indicator.component.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.ts
@@ -12,6 +12,7 @@ import {
 } from '../core/types/indicator';
 import { IonModalResponse } from '../modal/models/modal.interface';
 import { IonModalService } from './../modal/modal.service';
+import { IonIconProps } from '../core/types';
 
 @Component({
   selector: 'ion-indicator',
@@ -20,6 +21,7 @@ import { IonModalService } from './../modal/modal.service';
 })
 export class IonIndicatorComponent {
   @Input() title = 'Ion Indicator';
+  @Input() headerTitleIconConfig?: IonIconProps;
   @Input() tooltipText: string;
   @Input() secondValueTooltipText: string;
   @Input() value: number | string;

--- a/projects/ion/src/lib/indicator/indicator.component.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.ts
@@ -21,7 +21,7 @@ import { IonIconProps } from '../core/types';
 })
 export class IonIndicatorComponent {
   @Input() title = 'Ion Indicator';
-  @Input() headerTitleIconConfig?: IonIconProps;
+  @Input() headerTitleIconConfig?: Pick<IonIconProps, 'type' | 'color'>;
   @Input() tooltipText: string;
   @Input() secondValueTooltipText: string;
   @Input() value: number | string;

--- a/projects/ion/src/lib/indicator/indicator.component.ts
+++ b/projects/ion/src/lib/indicator/indicator.component.ts
@@ -21,7 +21,7 @@ import { IonIconProps } from '../core/types';
 })
 export class IonIndicatorComponent {
   @Input() title = 'Ion Indicator';
-  @Input() headerTitleIconConfig?: Pick<IonIconProps, 'type' | 'color'>;
+  @Input() headerIcon?: Pick<IonIconProps, 'type' | 'color'>;
   @Input() tooltipText: string;
   @Input() secondValueTooltipText: string;
   @Input() value: number | string;

--- a/stories/Indicator.stories.ts
+++ b/stories/Indicator.stories.ts
@@ -113,3 +113,23 @@ withOpenModal.args = {
   tooltipText: 'Texto personalizado via atributo tooltipText',
   buttonConfig: buttonModalConfig,
 };
+
+export const WithTitleIcon = Template.bind({});
+WithTitleIcon.args = {
+  title: 'Título personalizado via atributo title',
+  tooltipText: 'Texto personalizado via atributo tooltipText',
+  value: 1500,
+  secondValue: '5%',
+  headerTitleIconConfig: {
+    type: 'box',
+    color: '#FF0016',
+  },
+};
+
+export const WithLongTitle = Template.bind({});
+WithLongTitle.args = {
+  title:
+    'Título personalizado via atributo title via atributo titlevia atributo title',
+  value: 1500,
+  secondValue: '5%',
+};

--- a/stories/Indicator.stories.ts
+++ b/stories/Indicator.stories.ts
@@ -122,7 +122,6 @@ WithTitleIcon.args = {
   secondValue: '5%',
   headerTitleIconConfig: {
     type: 'box',
-    color: '#FF0016',
   },
 };
 

--- a/stories/Indicator.stories.ts
+++ b/stories/Indicator.stories.ts
@@ -120,7 +120,7 @@ WithTitleIcon.args = {
   tooltipText: 'Texto personalizado via atributo tooltipText',
   value: 1500,
   secondValue: '5%',
-  headerTitleIconConfig: {
+  headerIcon: {
     type: 'box',
   },
 };


### PR DESCRIPTION
## Issue Number

fix #1020 
fix #1019 

## Description

It was added the icon to appear conditionaly when you pass the config, and was added a tooltip to show the title in the cases where the title becomes partialy hidden.

## How to Test

yarn test indicator

## Screenshots

https://github.com/Brisanet/ion/assets/138060158/d0835ec0-95d7-4a8d-9296-733d8ccdd3f7

![image](https://github.com/Brisanet/ion/assets/138060158/1b939e92-e06b-445e-9dd9-e947603b4fc6)

## View Storybook

[Long title story](https://62eab350a45bdb0a5818520e-jrdbgeljpq.chromatic.com/?path=/story/ion-data-display-indicator--with-long-title)

[With header title icon](https://62eab350a45bdb0a5818520e-jrdbgeljpq.chromatic.com/?path=/story/ion-data-display-indicator--with-title-icon)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
