### PR TITLE
fix: remove border radius of ion-alert in modal #1026

### DIFF
--- a/projects/ion/src/lib/modal/component/modal.component.html
+++ b/projects/ion/src/lib/modal/component/modal.component.html
@@ -58,7 +58,7 @@
       [description]="configuration.alertConfig.description"
       [closable]="false"
       [hideBackground]="false"
-      [noRadius]="false"
+      [noRadius]="true"
     ></ion-alert>
 
     <div tabindex="0" class="modal-body">

--- a/projects/ion/src/lib/modal/component/modal.component.spec.ts
+++ b/projects/ion/src/lib/modal/component/modal.component.spec.ts
@@ -335,9 +335,7 @@ describe('IonModalComponent', () => {
     it('should render alert without border radius', () => {
       component.setConfig(configuration);
       fixture.detectChanges();
-      expect(
-        screen.getByTestId('ion-alert').classList.contains('no-border-radius')
-      );
+      expect(screen.getByTestId('ion-alert')).toHaveClass('no-radius');
     });
   });
 });

--- a/projects/ion/src/lib/modal/component/modal.component.spec.ts
+++ b/projects/ion/src/lib/modal/component/modal.component.spec.ts
@@ -335,8 +335,6 @@ describe('IonModalComponent', () => {
     it('should render alert without border radius', () => {
       component.setConfig(configuration);
       fixture.detectChanges();
-
-      screen.debug(screen.getByTestId('ion-alert'), 100000);
       expect(
         screen.getByTestId('ion-alert').classList.contains('no-border-radius')
       );

--- a/projects/ion/src/lib/modal/component/modal.component.spec.ts
+++ b/projects/ion/src/lib/modal/component/modal.component.spec.ts
@@ -332,7 +332,7 @@ describe('IonModalComponent', () => {
       ).toBeDefined();
     });
 
-    it('should alert with no border radius', () => {
+    it('should render alert without border radius', () => {
       component.setConfig(configuration);
       fixture.detectChanges();
 

--- a/projects/ion/src/lib/modal/component/modal.component.spec.ts
+++ b/projects/ion/src/lib/modal/component/modal.component.spec.ts
@@ -331,5 +331,15 @@ describe('IonModalComponent', () => {
         )
       ).toBeDefined();
     });
+
+    it('should alert with no border radius', () => {
+      component.setConfig(configuration);
+      fixture.detectChanges();
+
+      screen.debug(screen.getByTestId('ion-alert'), 100000);
+      expect(
+        screen.getByTestId('ion-alert').classList.contains('no-border-radius')
+      );
+    });
   });
 });


### PR DESCRIPTION
#1026

![image](https://github.com/Brisanet/ion/assets/138057813/7f3ba652-4698-4af0-a338-3c1dd6badf69)