### PR TITLE
feat: create truncation in breadcrumbs

### DIFF
--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.html
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,36 +1,39 @@
 <nav class="breadcrumbs-nav">
   <ol class="ol-navigator">
     <ng-container *ngFor="let breadcrumb of breadcrumbs; let index = index">
-      <li *ngIf="truncate && index === 1 && breadcrumbs.length > truncateLimit">
+      <li
+        *ngIf="
+          !truncate ||
+          (truncate && index <= 1) ||
+          index >= breadcrumbs.length - truncateLimit
+        "
+      >
         <ion-icon
+          *ngIf="truncate && index === 1 && breadcrumbs.length > truncateLimit"
           class="breadcrumbs-ellipsis"
           data-testid="breadcrumbs-ellipsis"
           type="more"
           [size]="16"
           (click)="openDropdown()"
         ></ion-icon>
+
+        <a
+          *ngIf="!truncate || (truncate && index !== 1)"
+          class="breacrumbs-link"
+          (click)="onSelected(breadcrumb)"
+        >
+          {{ breadcrumb.label }}
+        </a>
+
         <ion-icon class="icon" type="right2" [size]="16"></ion-icon>
 
         <ion-dropdown
-          *ngIf="isDropdownOpen"
+          *ngIf="isDropdownOpen && index === 1"
           data-testid="breadcrumbs-dropdown"
           class="breadcrumbs-dropdown"
           [options]="breadcrumbsInDropdown"
           (selected)="selectDropdownItem($event)"
         ></ion-dropdown>
-      </li>
-
-      <li
-        *ngIf="
-          !truncate ||
-          (truncate && index === 0) ||
-          index >= breadcrumbs.length - truncateLimit
-        "
-      >
-        <a (click)="onSelected(breadcrumb)" class="breacrumbs-link">
-          {{ breadcrumb.label }}
-        </a>
-        <ion-icon class="icon" type="right2" [size]="16"></ion-icon>
       </li>
     </ng-container>
   </ol>

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.html
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.html
@@ -4,12 +4,16 @@
       <li
         *ngIf="
           !truncate ||
-          (truncate && index <= 1) ||
+          (truncate && index <= ellipsesIndex) ||
           index >= breadcrumbs.length - truncateLimit
         "
       >
         <ion-icon
-          *ngIf="truncate && index === 1 && breadcrumbs.length > truncateLimit"
+          *ngIf="
+            truncate &&
+            index === ellipsesIndex &&
+            breadcrumbs.length > truncateLimit
+          "
           class="breadcrumbs-ellipsis"
           data-testid="breadcrumbs-ellipsis"
           type="more"
@@ -18,7 +22,7 @@
         ></ion-icon>
 
         <a
-          *ngIf="!truncate || (truncate && index !== 1)"
+          *ngIf="!truncate || (truncate && index !== ellipsesIndex)"
           class="breacrumbs-link"
           (click)="onSelected(breadcrumb)"
         >
@@ -28,7 +32,7 @@
         <ion-icon class="icon" type="right2" [size]="16"></ion-icon>
 
         <ion-dropdown
-          *ngIf="isDropdownOpen && index === 1"
+          *ngIf="isDropdownOpen && index === ellipsesIndex"
           data-testid="breadcrumbs-dropdown"
           class="breadcrumbs-dropdown"
           [options]="breadcrumbsInDropdown"

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.html
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,10 +1,37 @@
 <nav class="breadcrumbs-nav">
   <ol class="ol-navigator">
-    <li *ngFor="let breadcrumb of breadcrumbs">
-      <a (click)="onSelected(breadcrumb)" class="breacrumbs-link">
-        {{ breadcrumb.label }}
-      </a>
-      <ion-icon class="icon" type="right2" [size]="16"></ion-icon>
-    </li>
+    <ng-container *ngFor="let breadcrumb of breadcrumbs; let index = index">
+      <li *ngIf="truncate && index === 1 && breadcrumbs.length > truncateLimit">
+        <ion-icon
+          class="breadcrumbs-ellipsis"
+          data-testid="breadcrumbs-ellipsis"
+          type="more"
+          [size]="16"
+          (click)="openDropdown()"
+        ></ion-icon>
+        <ion-icon class="icon" type="right2" [size]="16"></ion-icon>
+
+        <ion-dropdown
+          *ngIf="isDropdownOpen"
+          data-testid="breadcrumbs-dropdown"
+          class="breadcrumbs-dropdown"
+          [options]="breadcrumbsInDropdown"
+          (selected)="selectDropdownItem($event)"
+        ></ion-dropdown>
+      </li>
+
+      <li
+        *ngIf="
+          !truncate ||
+          (truncate && index === 0) ||
+          index >= breadcrumbs.length - truncateLimit
+        "
+      >
+        <a (click)="onSelected(breadcrumb)" class="breacrumbs-link">
+          {{ breadcrumb.label }}
+        </a>
+        <ion-icon class="icon" type="right2" [size]="16"></ion-icon>
+      </li>
+    </ng-container>
   </ol>
 </nav>

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.html
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.html
@@ -10,9 +10,8 @@
       >
         <ion-icon
           *ngIf="
-            truncate &&
-            index === ellipsesIndex &&
-            breadcrumbs.length > truncateLimit
+            truncate && index === ellipsesIndex && breadcrumbsInDropdown.length;
+            else linkItem
           "
           class="breadcrumbs-ellipsis"
           data-testid="breadcrumbs-ellipsis"
@@ -21,13 +20,11 @@
           (click)="openDropdown()"
         ></ion-icon>
 
-        <a
-          *ngIf="!truncate || (truncate && index !== ellipsesIndex)"
-          class="breacrumbs-link"
-          (click)="onSelected(breadcrumb)"
-        >
-          {{ breadcrumb.label }}
-        </a>
+        <ng-template #linkItem>
+          <a class="breacrumbs-link" (click)="onSelected(breadcrumb)">
+            {{ breadcrumb.label }}
+          </a>
+        </ng-template>
 
         <ion-icon class="icon" type="right2" [size]="16"></ion-icon>
 
@@ -37,6 +34,7 @@
           class="breadcrumbs-dropdown"
           [options]="breadcrumbsInDropdown"
           (selected)="selectDropdownItem($event)"
+          (closeDropdown)="closeDropdown()"
         ></ion-dropdown>
       </li>
     </ng-container>

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.scss
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.scss
@@ -18,11 +18,34 @@
   gap: 8px;
   align-items: center;
   text-align: center;
+  position: relative;
 
-  ion-icon {
-    ::ng-deep svg {
-      fill: $neutral-5;
+  ::ng-deep {
+    ion-icon {
+      svg {
+        fill: $neutral-5;
+      }
+
+      &.breadcrumbs-ellipsis {
+        cursor: pointer;
+
+        &:hover svg,
+        &:active svg,
+        &:focus svg {
+          fill: $primary-6;
+        }
+
+        &:focus svg {
+          box-shadow: 0px 0px 0px $neutral-1, 0px 0px 0px $primary-5;
+        }
+      }
     }
+  }
+
+  .breadcrumbs-dropdown {
+    position: absolute;
+    bottom: 0;
+    left: -10px;
   }
 }
 

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -37,7 +37,7 @@ const defaultProps: BreadcrumbProps = {
   selected: {
     emit: selectEvent,
   } as unknown as EventEmitter<BreadcrumbItem>,
-  breadcrumbItems: items,
+  breadcrumbs: items,
   truncate: false,
 };
 

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -1,80 +1,145 @@
-import { IonIconModule } from './../icon/icon.module';
-import { SafeAny } from './../utils/safe-any';
 import { fireEvent, render, screen } from '@testing-library/angular';
-import {
-  IonBreadcrumbComponent,
-  BreadcrumbItem,
-  BreadcrumbProps,
-} from './breadcrumb.component';
+
+import { BreadcrumbItem, BreadcrumbProps } from '../core/types';
+import { IonIconModule } from './../icon/icon.module';
+import { IonBreadcrumbComponent } from './breadcrumb.component';
+import { EventEmitter } from '@angular/core';
+import { IonDropdownModule } from '../dropdown/dropdown.module';
 
 const selectEvent = jest.fn();
 
+const TRUNCATE_LIMIT = 5;
+
 const items: BreadcrumbItem[] = [
-  {
-    label: 'Inicio',
-    link: '/home',
-  },
-  {
-    label: 'Recursos',
-    link: '/recursos',
-  },
-  {
-    label: 'Tecnico',
-    link: '/recursos/1',
-  },
+  { label: 'Titulo 1', link: '/titulo1' },
+  { label: 'Titulo 2', link: '/titulo2' },
+  { label: 'Titulo 3', link: '/titulo3' },
+  { label: 'Titulo 4', link: '/titulo4' },
+  { label: 'Titulo 5', link: '/titulo5' },
+  { label: 'Titulo 6', link: '/titulo6' },
+  { label: 'Titulo 7', link: '/titulo7' },
+  { label: 'Titulo 8', link: '/titulo8' },
+  { label: 'Titulo 9', link: '/titulo9' },
 ];
 
+const visibleItemsAfterEllipsis: BreadcrumbItem[] = items.filter(
+  (_, index) => index >= items.length - TRUNCATE_LIMIT
+);
+
+const itemsInDropdown: BreadcrumbItem[] = items.filter(
+  (_, index) => index && index < items.length - TRUNCATE_LIMIT
+);
+
+const defaultProps: BreadcrumbProps = {
+  selected: {
+    emit: selectEvent,
+  } as unknown as EventEmitter<BreadcrumbItem>,
+  breadcrumbItems: items,
+  truncate: false,
+};
+
 const sut = async (
-  customProps: BreadcrumbProps = {
-    selected: {
-      emit: selectEvent,
-    },
-  } as SafeAny
+  customProps: BreadcrumbProps = defaultProps
 ): Promise<void> => {
   await render(IonBreadcrumbComponent, {
     componentProperties: {
       breadcrumbs: items,
       ...customProps,
     },
-    imports: [IonIconModule],
+    imports: [IonIconModule, IonDropdownModule],
   });
 };
 
 describe('Breadcrumb', () => {
-  beforeEach(async () => {
-    await sut();
+  afterEach(() => {
+    selectEvent.mockClear();
   });
 
-  it.each(items)(
-    'should render %s in breadcrumb',
-    async (link: BreadcrumbItem) => {
-      expect(screen.getByText(link.label)).toBeInTheDocument();
-    }
-  );
+  describe('elements rendered', () => {
+    it.each(items)(
+      'should render $label in breadcrumb',
+      async (link: BreadcrumbItem) => {
+        await sut({ ...defaultProps, truncate: false });
+        expect(screen.getByText(link.label)).toBeInTheDocument();
+      }
+    );
+  });
 
-  it('should render recursos in breadcrumb', async () => {
-    expect(screen.getByText('Recursos')).toHaveClass('breacrumbs-link');
+  describe('elements classes', () => {
+    it.each(items)(
+      'should set class breacrumbs-link in $label element',
+      async (item: BreadcrumbItem) => {
+        await sut();
+        expect(screen.getByText(item.label)).toHaveClass('breacrumbs-link');
+      }
+    );
   });
 
   it('should emit the selected breadcrumb', async () => {
+    await sut();
     const [firstItem] = items;
-
-    const element = screen.getByText(firstItem.label);
-    fireEvent.click(element);
+    fireEvent.click(screen.getByText(firstItem.label));
     expect(selectEvent).toBeCalledTimes(1);
     expect(selectEvent).toBeCalledWith(firstItem);
   });
 
   it('should not emit the selected breadcrumb is the last one', async () => {
+    await sut();
     const lastItem = items[items.length - 1];
-
-    const element = screen.getByText(lastItem.label);
-    fireEvent.click(element);
+    fireEvent.click(screen.getByText(lastItem.label));
     expect(selectEvent).toBeCalledTimes(0);
     expect(selectEvent).not.toBeCalledWith(lastItem);
   });
 
-  afterEach(() => {
-    selectEvent.mockClear();
+  describe('with truncation', () => {
+    beforeEach(async () => {
+      await sut({ ...defaultProps, truncate: true });
+    });
+
+    describe('elements rendered', () => {
+      const [firstItem] = items;
+
+      it(`should render ${firstItem.label} in breadcrumb`, async () => {
+        expect(screen.getByText(firstItem.label)).toBeInTheDocument();
+      });
+
+      it('should render "..." in breadcrumb', async () => {
+        expect(
+          screen.queryByTestId('breadcrumbs-ellipsis')
+        ).toBeInTheDocument();
+      });
+
+      it.each(visibleItemsAfterEllipsis)(
+        'should render $label in breadcrumb',
+        async (link: BreadcrumbItem) => {
+          expect(screen.queryByText(link.label)).toBeInTheDocument();
+        }
+      );
+    });
+
+    describe('breadcrumbs dropdown', () => {
+      it('should open dropdown when click in ellipsis', async () => {
+        fireEvent.click(screen.getByTestId('breadcrumbs-ellipsis'));
+        expect(
+          screen.queryByTestId('breadcrumbs-dropdown')
+        ).toBeInTheDocument();
+      });
+
+      it.each(itemsInDropdown)(
+        'should render $label in dropdown',
+        async (link: BreadcrumbItem) => {
+          fireEvent.click(screen.getByTestId('breadcrumbs-ellipsis'));
+          expect(screen.queryByText(link.label)).toBeInTheDocument();
+        }
+      );
+
+      it('should emit the selected element in dropdown', async () => {
+        fireEvent.click(screen.getByTestId('breadcrumbs-ellipsis'));
+        const [firstItem] = itemsInDropdown;
+        fireEvent.click(screen.getByText(firstItem.label));
+        expect(selectEvent).toBeCalledTimes(1);
+        expect(selectEvent).toBeCalledWith(firstItem);
+      });
+    });
   });
 });

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -1,8 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/angular';
 
-import { BreadcrumbItem, BreadcrumbProps } from '../core/types';
 import { IonIconModule } from './../icon/icon.module';
-import { IonBreadcrumbComponent } from './breadcrumb.component';
+import {
+  BreadcrumbItem,
+  BreadcrumbProps,
+  IonBreadcrumbComponent,
+} from './breadcrumb.component';
 import { EventEmitter } from '@angular/core';
 import { IonDropdownModule } from '../dropdown/dropdown.module';
 

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
@@ -1,4 +1,11 @@
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnInit,
+  OnChanges,
+} from '@angular/core';
 import { DropdownItem } from '../core/types/dropdown';
 
 export interface BreadcrumbItem {
@@ -7,7 +14,7 @@ export interface BreadcrumbItem {
 }
 
 export interface BreadcrumbProps {
-  breadcrumbItems: BreadcrumbItem[];
+  breadcrumbs: BreadcrumbItem[];
   selected: EventEmitter<BreadcrumbItem>;
   truncate?: boolean;
 }
@@ -17,8 +24,8 @@ export interface BreadcrumbProps {
   templateUrl: './breadcrumb.component.html',
   styleUrls: ['./breadcrumb.component.scss'],
 })
-export class IonBreadcrumbComponent implements OnInit {
-  @Input() breadcrumbs: BreadcrumbProps['breadcrumbItems'];
+export class IonBreadcrumbComponent implements OnChanges {
+  @Input() breadcrumbs: BreadcrumbProps['breadcrumbs'];
   @Input() truncate: BreadcrumbProps['truncate'] = true;
   @Output() selected = new EventEmitter<BreadcrumbItem>();
 
@@ -29,7 +36,6 @@ export class IonBreadcrumbComponent implements OnInit {
   public isDropdownOpen = false;
 
   public onSelected(item: BreadcrumbItem): void {
-    this.isDropdownOpen = false;
     if (item !== this.breadcrumbs[this.breadcrumbs.length - 1]) {
       this.selected.emit(item);
     }
@@ -39,6 +45,10 @@ export class IonBreadcrumbComponent implements OnInit {
     this.isDropdownOpen = true;
   }
 
+  public closeDropdown(): void {
+    this.isDropdownOpen = false;
+  }
+
   public selectDropdownItem(selecteds: DropdownItem[]): void {
     const [item] = selecteds;
     if (item) {
@@ -46,20 +56,26 @@ export class IonBreadcrumbComponent implements OnInit {
     }
   }
 
-  public ngOnInit(): void {
+  public ngOnChanges(): void {
+    this.breadcrumbsInDropdown = [];
+
     if (this.truncate) {
-      this.breadcrumbsInDropdown = this.breadcrumbs.reduce(
-        (acc, breadcrumb, index) => {
-          if (
-            index >= this.ellipsesIndex &&
-            index < this.breadcrumbs.length - this.truncateLimit
-          ) {
-            acc.push({ key: breadcrumb.link, label: breadcrumb.label });
-          }
-          return acc;
-        },
-        [] as DropdownItem[]
-      );
+      this.formatDropdownItems();
     }
+  }
+
+  private formatDropdownItems(): void {
+    this.breadcrumbsInDropdown = this.breadcrumbs.reduce(
+      (acc, { link, label }, index) => {
+        if (
+          index >= this.ellipsesIndex &&
+          index < this.breadcrumbs.length - this.truncateLimit
+        ) {
+          acc.push({ key: link, label });
+        }
+        return acc;
+      },
+      [] as DropdownItem[]
+    );
   }
 }

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
@@ -1,27 +1,50 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
-
-export interface BreadcrumbItem {
-  label: string;
-  link: string;
-}
-
-export interface BreadcrumbProps {
-  breadcrumbItems: BreadcrumbItem[];
-  selected: EventEmitter<BreadcrumbItem>;
-}
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { BreadcrumbItem, BreadcrumbProps } from '../core/types';
+import { DropdownItem } from 'ion/public-api';
 
 @Component({
   selector: 'ion-breadcrumb',
   templateUrl: './breadcrumb.component.html',
   styleUrls: ['./breadcrumb.component.scss'],
 })
-export class IonBreadcrumbComponent {
-  @Input() breadcrumbs: Array<BreadcrumbItem>;
+export class IonBreadcrumbComponent implements OnInit {
+  @Input() breadcrumbs: BreadcrumbProps['breadcrumbItems'];
+  @Input() truncate: BreadcrumbProps['truncate'] = true;
   @Output() selected = new EventEmitter<BreadcrumbItem>();
 
-  onSelected(item: BreadcrumbItem): void {
+  public readonly truncateLimit = 5;
+  public breadcrumbsInDropdown: DropdownItem[] = [];
+  public isDropdownOpen = false;
+
+  public onSelected(item: BreadcrumbItem): void {
+    this.isDropdownOpen = false;
     if (item !== this.breadcrumbs[this.breadcrumbs.length - 1]) {
       this.selected.emit(item);
+    }
+  }
+
+  public openDropdown(): void {
+    this.isDropdownOpen = true;
+  }
+
+  public selectDropdownItem(selecteds: DropdownItem[]): void {
+    const [item] = selecteds;
+    if (item) {
+      this.onSelected(this.breadcrumbs.find(({ link }) => link === item.key));
+    }
+  }
+
+  public ngOnInit(): void {
+    if (this.truncate) {
+      this.breadcrumbsInDropdown = this.breadcrumbs.reduce(
+        (acc, breadcrumb, index) => {
+          if (index && index < this.breadcrumbs.length - this.truncateLimit) {
+            acc.push({ key: breadcrumb.link, label: breadcrumb.label });
+          }
+          return acc;
+        },
+        [] as DropdownItem[]
+      );
     }
   }
 }

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
@@ -3,7 +3,6 @@ import {
   Input,
   Output,
   EventEmitter,
-  OnInit,
   OnChanges,
 } from '@angular/core';
 import { DropdownItem } from '../core/types/dropdown';

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
-import { DropdownItem } from 'ion/public-api';
+import { DropdownItem } from '../core/types/dropdown';
 
 export interface BreadcrumbItem {
   label: string;

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
@@ -23,6 +23,8 @@ export class IonBreadcrumbComponent implements OnInit {
   @Output() selected = new EventEmitter<BreadcrumbItem>();
 
   public readonly truncateLimit = 5;
+  public readonly ellipsesIndex = 1;
+
   public breadcrumbsInDropdown: DropdownItem[] = [];
   public isDropdownOpen = false;
 
@@ -48,7 +50,10 @@ export class IonBreadcrumbComponent implements OnInit {
     if (this.truncate) {
       this.breadcrumbsInDropdown = this.breadcrumbs.reduce(
         (acc, breadcrumb, index) => {
-          if (index && index < this.breadcrumbs.length - this.truncateLimit) {
+          if (
+            index >= this.ellipsesIndex &&
+            index < this.breadcrumbs.length - this.truncateLimit
+          ) {
             acc.push({ key: breadcrumb.link, label: breadcrumb.label });
           }
           return acc;

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.component.ts
@@ -1,6 +1,16 @@
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
-import { BreadcrumbItem, BreadcrumbProps } from '../core/types';
 import { DropdownItem } from 'ion/public-api';
+
+export interface BreadcrumbItem {
+  label: string;
+  link: string;
+}
+
+export interface BreadcrumbProps {
+  breadcrumbItems: BreadcrumbItem[];
+  selected: EventEmitter<BreadcrumbItem>;
+  truncate?: boolean;
+}
 
 @Component({
   selector: 'ion-breadcrumb',

--- a/projects/ion/src/lib/breadcrumb/breadcrumb.module.ts
+++ b/projects/ion/src/lib/breadcrumb/breadcrumb.module.ts
@@ -1,11 +1,13 @@
-import { IonIconModule } from './../icon/icon.module';
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { IonDropdownModule } from '../dropdown/dropdown.module';
+import { IonIconModule } from './../icon/icon.module';
 import { IonBreadcrumbComponent } from './breadcrumb.component';
 
 @NgModule({
   declarations: [IonBreadcrumbComponent],
-  imports: [CommonModule, IonIconModule],
+  imports: [CommonModule, IonIconModule, IonDropdownModule],
   exports: [IonBreadcrumbComponent],
 })
 export class IonBreadcrumbModule {}

--- a/projects/ion/src/lib/breadcrumb/mock/breadcrumb-truncated.component.ts
+++ b/projects/ion/src/lib/breadcrumb/mock/breadcrumb-truncated.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+
+import { BreadcrumbProps } from '../breadcrumb.component';
+
+@Component({
+  template: `
+    <div>
+      <ion-breadcrumb
+        [truncate]="args.truncate"
+        [breadcrumbs]="args.breadcrumbs"
+      ></ion-breadcrumb>
+    </div>
+  `,
+  styles: [],
+})
+export class BreadcrumbTruncatedComponent {
+  public args: Partial<BreadcrumbProps> = {
+    truncate: true,
+    breadcrumbs: Array.from({ length: 10 }, (_, index) => ({
+      label: `Titulo ${index}`,
+      link: `/titulo${index}`,
+    })),
+  };
+}

--- a/projects/ion/src/lib/core/types/breadcrumb.ts
+++ b/projects/ion/src/lib/core/types/breadcrumb.ts
@@ -1,3 +1,11 @@
+import { EventEmitter } from '@angular/core';
+
+export interface BreadcrumbProps {
+  breadcrumbItems: BreadcrumbItem[];
+  truncate?: boolean;
+  selected: EventEmitter<BreadcrumbItem>;
+}
+
 export interface BreadcrumbItem {
   label: string;
   link: string;

--- a/projects/ion/src/lib/core/types/breadcrumb.ts
+++ b/projects/ion/src/lib/core/types/breadcrumb.ts
@@ -1,11 +1,3 @@
-import { EventEmitter } from '@angular/core';
-
-export interface BreadcrumbProps {
-  breadcrumbItems: BreadcrumbItem[];
-  truncate?: boolean;
-  selected: EventEmitter<BreadcrumbItem>;
-}
-
 export interface BreadcrumbItem {
   label: string;
   link: string;

--- a/stories/Breadcrumb.stories.ts
+++ b/stories/Breadcrumb.stories.ts
@@ -1,7 +1,9 @@
-import { IonIconModule } from './../projects/ion/src/lib/icon/icon.module';
 import { CommonModule } from '@angular/common';
 import { Meta, Story } from '@storybook/angular';
+
 import { IonBreadcrumbComponent } from '../projects/ion/src/lib/breadcrumb/breadcrumb.component';
+import { IonDropdownModule } from '../projects/ion/src/lib/dropdown/dropdown.module';
+import { IonIconModule } from './../projects/ion/src/lib/icon/icon.module';
 
 export default {
   title: 'Ion/Navigation/Breadcrumb',
@@ -15,17 +17,29 @@ const Template: Story<IonBreadcrumbComponent> = (
   props: args,
   moduleMetadata: {
     declarations: [IonBreadcrumbComponent],
-    imports: [CommonModule, IonIconModule],
+    imports: [CommonModule, IonIconModule, IonDropdownModule],
   },
 });
 
 const breadcrumbs = [
-  { label: 'Home', link: '/home' },
-  { label: 'Recursos', link: '/recursos' },
-  { label: 'Técnico', link: '/recursos/1' },
+  { label: 'Titulo 1', link: '/titulo1' },
+  { label: 'Titulo 2', link: '/titulo2' },
+  { label: 'Titulo 3', link: '/titulo3' },
+  { label: 'Titulo 4', link: '/titulo4' },
+  { label: 'Titulo 5', link: '/titulo5' },
+  { label: 'Titulo 6', link: '/titulo6' },
+  { label: 'Titulo 7', link: '/titulo7' },
+  { label: 'Titulo 8', link: '/titulo8' },
+  { label: 'Titulo 9', link: '/titulo9' },
 ];
 
 export const Initials = Template.bind({});
 Initials.args = {
   breadcrumbs,
+};
+
+export const WithTruncation = Template.bind({});
+WithTruncation.args = {
+  breadcrumbs,
+  truncate: true,
 };

--- a/stories/Breadcrumb.stories.ts
+++ b/stories/Breadcrumb.stories.ts
@@ -2,8 +2,12 @@ import { CommonModule } from '@angular/common';
 import { Meta, Story } from '@storybook/angular';
 
 import { IonBreadcrumbComponent } from '../projects/ion/src/lib/breadcrumb/breadcrumb.component';
-import { IonDropdownModule } from '../projects/ion/src/lib/dropdown/dropdown.module';
-import { IonIconModule } from './../projects/ion/src/lib/icon/icon.module';
+import {
+  IonBreadcrumbModule,
+  IonDropdownModule,
+  IonIconModule,
+} from '../projects/ion/src/public-api';
+import { BreadcrumbTruncatedComponent } from '../projects/ion/src/lib/breadcrumb/mock/breadcrumb-truncated.component';
 
 export default {
   title: 'Ion/Navigation/Breadcrumb',
@@ -21,25 +25,27 @@ const Template: Story<IonBreadcrumbComponent> = (
   },
 });
 
-const breadcrumbs = [
-  { label: 'Titulo 1', link: '/titulo1' },
-  { label: 'Titulo 2', link: '/titulo2' },
-  { label: 'Titulo 3', link: '/titulo3' },
-  { label: 'Titulo 4', link: '/titulo4' },
-  { label: 'Titulo 5', link: '/titulo5' },
-  { label: 'Titulo 6', link: '/titulo6' },
-  { label: 'Titulo 7', link: '/titulo7' },
-  { label: 'Titulo 8', link: '/titulo8' },
-  { label: 'Titulo 9', link: '/titulo9' },
-];
-
-export const Initials = Template.bind({});
-Initials.args = {
-  breadcrumbs,
+export const WithoutTruncation = Template.bind({});
+WithoutTruncation.args = {
+  breadcrumbs: [
+    { label: 'Home', link: '/home' },
+    { label: 'Recursos', link: '/recursos' },
+    { label: 'Técnico', link: '/recursos/1' },
+  ],
+  truncate: false,
 };
 
-export const WithTruncation = Template.bind({});
-WithTruncation.args = {
-  breadcrumbs,
-  truncate: true,
-};
+const TemplateTruncated: Story<BreadcrumbTruncatedComponent> = (
+  args: BreadcrumbTruncatedComponent
+) => ({
+  component: BreadcrumbTruncatedComponent,
+  props: args,
+  moduleMetadata: {
+    declarations: [BreadcrumbTruncatedComponent],
+    entryComponents: [BreadcrumbTruncatedComponent],
+    imports: [IonBreadcrumbModule],
+  },
+});
+
+export const WithTruncation = TemplateTruncated.bind({});
+WithTruncation.args = {};


### PR DESCRIPTION
## #1033 

## Description

This feature aims to enhance the breadcrumbs functionality by introducing a truncation mechanism. When navigating through a deep hierarchy of pages, breadcrumbs can become excessively long, causing layout issues and decreasing usability. Therefore, this feature will provide the ability to truncate the breadcrumbs display while still maintaining navigational context.

![image](https://github.com/Brisanet/ion/assets/138119077/04126c35-6038-462f-a55f-6fb824ff6c4c)

https://github.com/Brisanet/ion/assets/138119077/ca7f97be-2d42-43c0-9a40-f4ba23327c0a

## View Storybook

https://62eab350a45bdb0a5818520e-bajwoiopcg.chromatic.com/?path=/story/ion-navigation-breadcrumb--with-truncation

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
