### PR TITLE
feat: modal prevent close on confirm and custom class

### DIFF
--- a/projects/ion/src/lib/modal/component/modal.component.html
+++ b/projects/ion/src/lib/modal/component/modal.component.html
@@ -1,6 +1,9 @@
 <div
+  [ngClass]="
+    (configuration.customClass ? configuration.customClass : '') +
+    ' modal-overlay'
+  "
   [class.hide]="!configuration.showOverlay"
-  class="modal-overlay"
   data-testid="modalOverlay"
   (click)="configuration.overlayCanDismiss && closeModal()"
 >

--- a/projects/ion/src/lib/modal/component/modal.component.spec.ts
+++ b/projects/ion/src/lib/modal/component/modal.component.spec.ts
@@ -222,6 +222,37 @@ describe('IonModalComponent', () => {
     expect(modalElement).toBe(`${modalConfig.width}px`);
   });
 
+  it('should render the modal with a custom class when informed', () => {
+    const customClass = 'custom-modal';
+    const configuration: IonModalConfiguration = {
+      id: '1',
+      title: 'Ion Test',
+
+      footer: {
+        showDivider: false,
+        primaryButton: {
+          label: 'Ion Cancel',
+          iconType: 'icon',
+        },
+        secondaryButton: {
+          label: 'Ion Confirm',
+          iconType: 'icon',
+        },
+      },
+      customClass,
+
+      headerButton: {
+        icon: 'left',
+        label: 'voltar',
+      },
+    };
+    component.setConfig(configuration);
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(screen.getByTestId('modalOverlay')).toHaveClass(customClass);
+  });
+
   describe('IonModalComponent - Header left button', () => {
     const configuration: IonModalConfiguration = {
       id: '1',

--- a/projects/ion/src/lib/modal/mock/open-modal.mock.component.ts
+++ b/projects/ion/src/lib/modal/mock/open-modal.mock.component.ts
@@ -21,7 +21,7 @@ export class OpenModalButtonComponent {
 
   openModal(): void {
     this.ionModalService
-      .open(this.componentToBody)
+      .open(this.componentToBody, this.modalConfig)
       .subscribe((response: IonModalResponse) => {
         this.valueFromModal = response;
       });

--- a/projects/ion/src/lib/modal/mock/open-modal.mock.component.ts
+++ b/projects/ion/src/lib/modal/mock/open-modal.mock.component.ts
@@ -21,7 +21,7 @@ export class OpenModalButtonComponent {
 
   openModal(): void {
     this.ionModalService
-      .open(this.componentToBody, this.modalConfig)
+      .open(this.componentToBody)
       .subscribe((response: IonModalResponse) => {
         this.valueFromModal = response;
       });

--- a/projects/ion/src/lib/modal/modal.service.spec.ts
+++ b/projects/ion/src/lib/modal/modal.service.spec.ts
@@ -82,7 +82,7 @@ describe('ModalService', () => {
     expect(modalService.closeModal).toHaveBeenCalled();
   });
 
-  it('should call emitValueAndCloseModal when ionOnClose fires without value', () => {
+  it('should call emitValueAndCloseModal when ionOnClose fires with value', () => {
     jest.spyOn(modalService, 'emitValueAndCloseModal');
 
     modalService.open(SelectMockComponent);
@@ -162,5 +162,19 @@ describe('ModalService', () => {
 
     expect(modalService.closeModal).toHaveBeenCalled();
     expect(screen.getByTestId('modal')).toHaveAttribute('id', 'modal-2');
+  });
+
+  it('should not close modal by clicking the primary button when preventCloseOnConfirm is informed', () => {
+    jest.spyOn(modalService, 'emitValue');
+
+    modalService.open(SelectMockComponent, { preventCloseOnConfirm: true });
+
+    fireEvent.click(screen.getByText('Confirmar'));
+    fixture.detectChanges();
+
+    expect(modalService.emitValue).toHaveBeenCalledWith({
+      state: 'ceara',
+    });
+    expect(screen.getByTestId('modal')).toBeVisible();
   });
 });

--- a/projects/ion/src/lib/modal/modal.service.ts
+++ b/projects/ion/src/lib/modal/modal.service.ts
@@ -70,6 +70,14 @@ export class IonModalService {
           return;
         }
 
+        if (
+          this.currentModalControl.ref.instance.configuration
+            .preventCloseOnConfirm
+        ) {
+          this.emitValue(valueFromModal);
+          return;
+        }
+
         this.emitValueAndCloseModal(valueFromModal);
       }
     );
@@ -81,6 +89,10 @@ export class IonModalService {
     );
 
     return this.currentModalControl.subscriber.asObservable();
+  }
+
+  emitValue(valueToEmit: IonModalResponse | unknown): void {
+    this.currentModalControl.subscriber.next(valueToEmit);
   }
 
   emitValueAndCloseModal(valueToEmit: IonModalResponse | unknown): void {

--- a/projects/ion/src/lib/modal/models/modal.interface.ts
+++ b/projects/ion/src/lib/modal/models/modal.interface.ts
@@ -16,8 +16,9 @@ export interface IonModalConfiguration {
   hideCloseButton?: boolean;
   headerButton?: IonModalHeaderButton;
   alertConfig?: Pick<IonAlertProps, 'message' | 'type' | 'description'>;
-
+  preventCloseOnConfirm?: boolean;
   footer?: IonModalFooterConfiguration;
+  customClass?: string;
 }
 
 export interface IonModalFooterConfiguration {


### PR DESCRIPTION
## Issue Number

fix #1041 
fix #1040 

## Description

It was added a property "preventCloseOnConfirm" so it wont close at primary action and a property "customClass" to provide more css flexibility, to the modal configuration.

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.