### PR TITLE
feat: adding vertical variant to ion-steps (#1044)

### DIFF
--- a/projects/ion/src/lib/core/types/index.ts
+++ b/projects/ion/src/lib/core/types/index.ts
@@ -28,6 +28,7 @@ export * from './simple-menu';
 export * from './smart-table';
 export * from './spinner';
 export * from './status';
+export * from './steps';
 export * from './switch';
 export * from './tab';
 export * from './tab-group';

--- a/projects/ion/src/lib/core/types/steps.ts
+++ b/projects/ion/src/lib/core/types/steps.ts
@@ -1,3 +1,5 @@
+import { DirectionType } from './direction';
+
 export interface StepType {
   label: string;
   description?: string;
@@ -17,7 +19,7 @@ export type StepConfig = {
   disabled?: boolean;
   steps: StepType[];
   clickable?: boolean;
-  direction?: StepDirection;
+  direction?: DirectionType;
   preventStepChange?: boolean;
 };
 
@@ -26,9 +28,4 @@ export enum StepStatus {
   SELECTED = 'selected',
   CHECKED = 'checked',
   ERROR = 'error',
-}
-
-export enum StepDirection {
-  HORIZONTAL = 'horizontal',
-  VERTICAL = 'vertical',
 }

--- a/projects/ion/src/lib/core/types/steps.ts
+++ b/projects/ion/src/lib/core/types/steps.ts
@@ -1,24 +1,34 @@
-export type StatusType = 'default' | 'selected' | 'checked' | 'error';
-
 export interface StepType {
   label: string;
   description?: string;
   index?: number;
-  status?: StatusType;
+  status?: StepStatus;
+  lines?: StepLines;
+  clickableWhenHasError?: boolean;
 }
 
-export type LineType = 'initial' | 'final';
+export interface StepLines {
+  isPreviousBolded: boolean;
+  isNextBolded: boolean;
+}
 
 export type StepConfig = {
   current: number;
   disabled?: boolean;
   steps: StepType[];
   clickable?: boolean;
+  direction?: StepDirection;
+  preventStepChange?: boolean;
 };
 
-export enum Status {
-  default = 'default',
-  selected = 'selected',
-  checked = 'checked',
-  error = 'error',
+export enum StepStatus {
+  DEFAULT = 'default',
+  SELECTED = 'selected',
+  CHECKED = 'checked',
+  ERROR = 'error',
+}
+
+export enum StepDirection {
+  HORIZONTAL = 'horizontal',
+  VERTICAL = 'vertical',
 }

--- a/projects/ion/src/lib/step/step.component.html
+++ b/projects/ion/src/lib/step/step.component.html
@@ -1,25 +1,34 @@
-<section class="steps-container" data-testid="ion-steps">
+<section
+  class="steps-container"
+  data-testid="ion-steps"
+  [ngClass]="'step-direction-' + direction"
+>
   <div
     [class]="'step ' + step.status"
     [class.clickable]="
       clickable &&
       !disabled &&
       step.status !== 'selected' &&
-      step.status !== 'error'
+      (step.status !== 'error' ||
+        (step.status === 'error' && step.clickableWhenHasError))
     "
     [class.disabled]="disabled"
     [attr.data-testid]="'step-' + step.index + '-' + step.status"
     *ngFor="let step of steps; let index = index"
     (click)="goesTo(step.index)"
   >
+    <ng-container
+      *ngIf="direction === 'vertical' && step.index !== FIRST_STEP"
+      [ngTemplateOutlet]="line"
+      [ngTemplateOutletContext]="{ $implicit: step, inLeft: true }"
+    ></ng-container>
+
     <div class="step-draw">
-      <div
-        class="line"
-        [class.bolded]="
-          steps[index - 1] && steps[index - 1].status === 'checked'
-        "
-        [class.transparent]="step.index === FIRST_STEP"
-      ></div>
+      <ng-container
+        *ngIf="direction === 'horizontal'"
+        [ngTemplateOutlet]="line"
+        [ngTemplateOutletContext]="{ $implicit: step, inLeft: true }"
+      ></ng-container>
 
       <div class="circle">
         <span *ngIf="step.status !== 'checked'; else checkedStatus">
@@ -32,31 +41,51 @@
         </ng-template>
       </div>
 
-      <div
-        class="line"
-        [class.bolded]="
-          steps[index].status === 'checked' ||
-          (steps[index + 1] && steps[index + 1].status !== 'default')
-        "
-        [class.transparent]="step.index === steps.length"
-      ></div>
+      <ng-container
+        [ngTemplateOutlet]="direction === 'horizontal' ? line : label"
+        [ngTemplateOutletContext]="{ $implicit: step }"
+      ></ng-container>
     </div>
 
-    <div
+    <ng-container
+      *ngIf="direction !== 'vertical' || step.index !== steps.length"
+      [ngTemplateOutlet]="direction === 'vertical' ? line : label"
+      [ngTemplateOutletContext]="{ $implicit: step }"
+    ></ng-container>
+  </div>
+</section>
+
+<ng-template #label let-step>
+  <div class="text-container">
+    <span
       class="label"
       [class.selected]="step.status === 'selected' || step.status === 'error'"
       [class.disabled]="disabled"
     >
       {{ step.label }}
-    </div>
+    </span>
 
-    <div
+    <span
+      *ngIf="step.description"
       class="description"
       [class.disabled]="disabled"
       [attr.data-testid]="'description-' + step.index"
-      *ngIf="step.description"
     >
-      {{ step.description }}
-    </div>
+      {{ step.description | ellipsis: 58 }}
+    </span>
   </div>
-</section>
+</ng-template>
+
+<ng-template #line let-step let-inLeft="inLeft">
+  <div
+    *ngIf="step.lines"
+    [ngClass]="'line line-direction-' + direction"
+    [class.bolded]="
+      inLeft ? step.lines.isPreviousBolded : step.lines.isNextBolded
+    "
+    [class.transparent]="
+      (inLeft && step.index === FIRST_STEP) ||
+      (!inLeft && step.index === steps.length)
+    "
+  ></div>
+</ng-template>

--- a/projects/ion/src/lib/step/step.component.scss
+++ b/projects/ion/src/lib/step/step.component.scss
@@ -17,6 +17,14 @@
 
 .steps-container {
   display: flex;
+
+  &.step-direction-vertical {
+    flex-direction: column;
+  }
+
+  &.step-direction-horizontal .step {
+    align-items: center;
+  }
 }
 
 .step {
@@ -26,20 +34,6 @@
   .step-draw {
     display: flex;
     align-items: center;
-
-    .line {
-      width: 64.5px;
-      height: 1px;
-      background-color: $neutral-4;
-
-      &.bolded {
-        background-color: $primary-6;
-      }
-
-      &.transparent {
-        background-color: transparent !important;
-      }
-    }
 
     .circle {
       box-sizing: content-box;
@@ -60,36 +54,63 @@
     }
   }
 
-  .label,
-  .description {
-    color: $neutral-6;
-    font-family: 'Inter', sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    word-break: break-all;
-    padding: spacing(0.5) spacing(1);
-    box-sizing: border-box;
-    text-align: center;
-    max-width: 183px;
-  }
+  .line {
+    width: 64.5px;
+    height: 1px;
+    background-color: $neutral-4;
 
-  .label {
-    font-size: 14px;
-    line-height: 20px;
-
-    &.selected {
-      color: $neutral-7;
+    &.bolded {
+      background-color: $primary-6;
     }
 
-    &.disabled,
-    &.disabled.selected {
-      color: $neutral-5;
+    &.transparent {
+      background-color: transparent !important;
+    }
+
+    &.line-direction-vertical {
+      width: 1px;
+      height: 64.5px;
+      margin-left: 27px;
     }
   }
 
-  .description {
-    font-size: 12px;
-    line-height: 16px;
+  .text-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: fit-content;
+
+    .label,
+    .description {
+      color: $neutral-6;
+      font-family: 'Inter', sans-serif;
+      font-style: normal;
+      font-weight: 400;
+      word-break: break-all;
+      padding: 0 spacing(1);
+      box-sizing: border-box;
+      text-align: center;
+      max-width: 183px;
+    }
+
+    .label {
+      font-size: 14px;
+      line-height: 20px;
+
+      &.selected {
+        color: $neutral-7;
+      }
+
+      &.disabled,
+      &.disabled.selected {
+        color: $neutral-5;
+      }
+    }
+
+    .description {
+      font-size: 12px;
+      line-height: 16px;
+    }
   }
 
   &.default {
@@ -125,11 +146,15 @@
 
 .step.clickable {
   cursor: pointer;
+
   &:hover,
   &:active {
-    .label,
-    .description {
+    .text-container * {
       color: $primary-5;
+    }
+
+    &.error .text-container * {
+      color: $negative-5;
     }
   }
 

--- a/projects/ion/src/lib/step/step.component.spec.ts
+++ b/projects/ion/src/lib/step/step.component.spec.ts
@@ -2,12 +2,7 @@ import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { fireEvent, render, screen } from '@testing-library/angular';
-import {
-  StepConfig,
-  StepType,
-  StepDirection,
-  StepStatus,
-} from '../core/types/steps';
+import { StepConfig, StepType, StepStatus } from '../core/types/steps';
 import { IonIconComponent } from '../icon/icon.component';
 import { IonStepsComponent } from './step.component';
 import { PipesModule } from '../utils/pipes/pipes.module';
@@ -51,7 +46,7 @@ describe('Static IonStepsComponent', () => {
   });
 
   it('should render step in vertical direction', async () => {
-    await sut({ ...defaultProps, direction: StepDirection.VERTICAL });
+    await sut({ ...defaultProps, direction: 'vertical' });
     expect(screen.getByTestId('ion-steps')).toHaveClass(
       'step-direction-vertical'
     );

--- a/projects/ion/src/lib/step/step.component.ts
+++ b/projects/ion/src/lib/step/step.component.ts
@@ -7,7 +7,7 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
-import { StepStatus, StepType, StepConfig, StepDirection } from '../core/types';
+import { StepStatus, StepType, StepConfig } from '../core/types';
 
 @Component({
   selector: 'ion-steps',
@@ -15,12 +15,12 @@ import { StepStatus, StepType, StepConfig, StepDirection } from '../core/types';
   styleUrls: ['./step.component.scss'],
 })
 export class IonStepsComponent implements OnInit, OnChanges {
-  @Input() current = 1;
-  @Input() steps: StepType[];
-  @Input() disabled = false;
-  @Input() clickable: boolean;
-  @Input() preventStepChange = false;
-  @Input() direction: StepConfig['direction'] = StepDirection.HORIZONTAL;
+  @Input() current: StepConfig['current'] = 1;
+  @Input() steps: StepConfig['steps'];
+  @Input() disabled: StepConfig['disabled'] = false;
+  @Input() clickable: StepConfig['clickable'];
+  @Input() preventStepChange: StepConfig['preventStepChange'] = false;
+  @Input() direction: StepConfig['direction'] = 'horizontal';
   @Output() indexChange = new EventEmitter<number>();
 
   public firstCatchStatus = true;

--- a/projects/ion/src/lib/step/step.component.ts
+++ b/projects/ion/src/lib/step/step.component.ts
@@ -7,7 +7,7 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
-import { Status, StatusType, StepType } from '../core/types/steps';
+import { StepStatus, StepType, StepConfig, StepDirection } from '../core/types';
 
 @Component({
   selector: 'ion-steps',
@@ -19,24 +19,26 @@ export class IonStepsComponent implements OnInit, OnChanges {
   @Input() steps: StepType[];
   @Input() disabled = false;
   @Input() clickable: boolean;
+  @Input() preventStepChange = false;
+  @Input() direction: StepConfig['direction'] = StepDirection.HORIZONTAL;
   @Output() indexChange = new EventEmitter<number>();
 
   public firstCatchStatus = true;
 
   FIRST_STEP = 1;
 
-  stepStatus(step: StepType, currentIndex: number): StatusType {
-    if (step.index < currentIndex) return Status.checked;
-    if (step.index === currentIndex) return Status.selected;
-    return Status.default;
+  stepStatus(step: StepType, currentIndex: number): StepStatus {
+    if (step.index < currentIndex) return StepStatus.CHECKED;
+    if (step.index === currentIndex) return StepStatus.SELECTED;
+    return StepStatus.DEFAULT;
   }
 
-  checkStartedStatus(step: StepType, currentIndex: number): StatusType {
+  checkStartedStatus(step: StepType, currentIndex: number): StepStatus {
     return step.status ? step.status : this.stepStatus(step, currentIndex);
   }
 
   changeStep(currentIndex: number): void {
-    if (currentIndex < 1 || currentIndex > this.steps.length) {
+    if (currentIndex < this.FIRST_STEP || currentIndex > this.steps.length) {
       return;
     }
 
@@ -49,13 +51,16 @@ export class IonStepsComponent implements OnInit, OnChanges {
       };
     });
 
+    this.formatStepLines();
     this.firstCatchStatus = false;
   }
 
   goesTo(index: number): void {
     if (this.clickable && !this.disabled) {
       this.indexChange.emit(index);
-      this.changeStep(index);
+      if (!this.preventStepChange) {
+        this.changeStep(index);
+      }
     }
   }
 
@@ -67,6 +72,9 @@ export class IonStepsComponent implements OnInit, OnChanges {
     if (changes.current && !changes.current.firstChange) {
       this.changeStep(changes.current.currentValue);
     }
+    if (changes.steps && !changes.steps.firstChange) {
+      this.formatStepLines();
+    }
   }
 
   private generateIndexesForStep(): void {
@@ -74,5 +82,26 @@ export class IonStepsComponent implements OnInit, OnChanges {
       step.index = index + 1;
     });
     this.changeStep(this.current);
+  }
+
+  private formatStepLines(): void {
+    this.steps = this.steps.map((step, index) => ({
+      ...step,
+      lines: {
+        isPreviousBolded: this.shouldConnectSteps(this.steps[index - 1], step),
+        isNextBolded: this.shouldConnectSteps(step, this.steps[index + 1]),
+      },
+    }));
+  }
+
+  private shouldConnectSteps(
+    firstStep?: StepType,
+    secondStep?: StepType
+  ): boolean {
+    return (
+      !!firstStep &&
+      !!secondStep &&
+      ![firstStep.status, secondStep.status].includes(StepStatus.DEFAULT)
+    );
   }
 }

--- a/projects/ion/src/lib/step/step.module.ts
+++ b/projects/ion/src/lib/step/step.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IonStepsComponent } from './step.component';
 import { IonIconModule } from '../icon/icon.module';
+import { PipesModule } from '../utils/pipes/pipes.module';
 
 @NgModule({
   declarations: [IonStepsComponent],
-  imports: [CommonModule, IonIconModule],
+  imports: [CommonModule, IonIconModule, PipesModule],
   exports: [IonStepsComponent],
 })
 export class IonStepsModule {}

--- a/projects/ion/src/lib/utils/pipes/ellipsis/ellipses.pipe.spec.ts
+++ b/projects/ion/src/lib/utils/pipes/ellipsis/ellipses.pipe.spec.ts
@@ -1,0 +1,23 @@
+import { EllipsisPipe } from './ellipsis.pipe';
+
+const text = 'Hello World';
+
+describe('EllipsisPipe', () => {
+  let pipe: EllipsisPipe;
+
+  beforeEach(() => {
+    pipe = new EllipsisPipe();
+  });
+
+  it('should create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return string without ellipsis if length is less than limit', () => {
+    expect(pipe.transform(text, 15)).toEqual(text);
+  });
+
+  it('should return string with ellipsis if length is greater than limit', () => {
+    expect(pipe.transform(text, 5)).toEqual('Hello...');
+  });
+});

--- a/projects/ion/src/lib/utils/pipes/ellipsis/ellipsis.pipe.ts
+++ b/projects/ion/src/lib/utils/pipes/ellipsis/ellipsis.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'ellipsis',
+})
+export class EllipsisPipe implements PipeTransform {
+  transform(value: string, limit: number): string {
+    if (limit && value.length > limit) {
+      return value.substring(0, limit).concat('...');
+    }
+    return value;
+  }
+}

--- a/projects/ion/src/lib/utils/pipes/ellipsis/index.ts
+++ b/projects/ion/src/lib/utils/pipes/ellipsis/index.ts
@@ -1,0 +1,1 @@
+export * from './ellipsis.pipe';

--- a/projects/ion/src/lib/utils/pipes/pipes.module.ts
+++ b/projects/ion/src/lib/utils/pipes/pipes.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
 import { ReplaceEmptyPipe } from './replace-empty';
+import { EllipsisPipe } from './ellipsis/ellipsis.pipe';
 
 @NgModule({
-  declarations: [ReplaceEmptyPipe],
-  exports: [ReplaceEmptyPipe],
-  providers: [ReplaceEmptyPipe],
+  declarations: [ReplaceEmptyPipe, EllipsisPipe],
+  exports: [ReplaceEmptyPipe, EllipsisPipe],
+  providers: [ReplaceEmptyPipe, EllipsisPipe],
 })
 export class PipesModule {}

--- a/stories/Step.stories.ts
+++ b/stories/Step.stories.ts
@@ -1,6 +1,5 @@
 import { Meta, moduleMetadata, Story } from '@storybook/angular';
 
-import { StepDirection } from '../projects/ion/src/lib/core/types/steps';
 import { IonIconComponent } from '../projects/ion/src/lib/icon/icon.component';
 import { IonStepsComponent } from '../projects/ion/src/lib/step/step.component';
 import { PipesModule } from '../projects/ion/src/lib/utils/pipes/pipes.module';
@@ -42,7 +41,7 @@ export default {
     direction: {
       name: 'direction',
       control: 'radio',
-      options: [...Object.values(StepDirection)],
+      options: ['horizontal', 'vertical'],
       defaultValue: 'horizontal',
     },
   },
@@ -155,6 +154,7 @@ WithLongDescription.args = {
 
 export const PreventStepChange = Template.bind({});
 PreventStepChange.args = {
+  clickable: true,
   preventStepChange: true,
   steps: [
     {

--- a/stories/Step.stories.ts
+++ b/stories/Step.stories.ts
@@ -1,6 +1,9 @@
 import { Meta, moduleMetadata, Story } from '@storybook/angular';
+
+import { StepDirection } from '../projects/ion/src/lib/core/types/steps';
 import { IonIconComponent } from '../projects/ion/src/lib/icon/icon.component';
 import { IonStepsComponent } from '../projects/ion/src/lib/step/step.component';
+import { PipesModule } from '../projects/ion/src/lib/utils/pipes/pipes.module';
 
 export default {
   title: 'Ion/Navigation/Steps',
@@ -8,8 +11,41 @@ export default {
   decorators: [
     moduleMetadata({
       declarations: [IonIconComponent],
+      imports: [PipesModule],
     }),
   ],
+  argTypes: {
+    current: {
+      name: 'current',
+      control: 'number',
+      defaultValue: 1,
+    },
+    steps: {
+      name: 'steps',
+      type: { name: 'array' },
+    },
+    disabled: {
+      name: 'disabled',
+      type: { name: 'boolean' },
+      defaultValue: false,
+    },
+    clickable: {
+      name: 'clickable',
+      type: { name: 'boolean' },
+      defaultValue: false,
+    },
+    preventStepChange: {
+      name: 'preventStepChange',
+      type: { name: 'boolean' },
+      defaultValue: false,
+    },
+    direction: {
+      name: 'direction',
+      control: 'radio',
+      options: [...Object.values(StepDirection)],
+      defaultValue: 'horizontal',
+    },
+  },
 } as Meta;
 
 const Template: Story<IonStepsComponent> = (args: IonStepsComponent) => ({
@@ -87,5 +123,73 @@ WithError.args = {
     {
       label: 'Fourty',
     },
+  ],
+};
+
+export const Vertical = Template.bind({});
+Vertical.args = {
+  direction: 'vertical',
+  steps: [
+    {
+      label: 'First',
+      description: '(optional)',
+    },
+    { label: 'Second' },
+    { label: 'Third' },
+  ],
+};
+
+export const WithLongDescription = Template.bind({});
+WithLongDescription.args = {
+  direction: 'vertical',
+  steps: [
+    {
+      label: 'First',
+      description:
+        'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.',
+    },
+    { label: 'Second' },
+    { label: 'Third' },
+  ],
+};
+
+export const PreventStepChange = Template.bind({});
+PreventStepChange.args = {
+  preventStepChange: true,
+  steps: [
+    {
+      label: 'First',
+      description: '(optional)',
+    },
+    { label: 'Second' },
+    { label: 'Third' },
+  ],
+};
+
+export const WithErrorInOtherStep = Template.bind({});
+WithErrorInOtherStep.args = {
+  steps: [
+    {
+      label: 'First',
+      description: '(optional)',
+      status: 'error',
+    },
+    { label: 'Second', status: 'checked' },
+    { label: 'Third', status: 'selected' },
+  ],
+};
+
+export const WithStepClickableWhenHasError = Template.bind({});
+WithStepClickableWhenHasError.args = {
+  clickable: true,
+  steps: [
+    {
+      label: 'First',
+      description: '(optional)',
+      status: 'error',
+      clickableWhenHasError: true,
+    },
+    { label: 'Second', status: 'checked' },
+    { label: 'Third', status: 'selected' },
   ],
 };


### PR DESCRIPTION
#1044 

# Adding vertical variant to ion-steps (#1044 )

## Description

- Creating a vertical variant to ion-steps
- Adding "preventStepChange" to don't change automatically when click (usefull in cases that we need to do some validations before change step)
- Exporting step types and remove unused types

## Screenshots

| source | screenshot |
| --- | --- |
| yoda | <img height="350" src="https://github.com/Brisanet/ion/assets/138119077/9127356f-244c-47cd-ab81-0cd475ed66ea" />|
| storybook | <img height="350" src="https://github.com/Brisanet/ion/assets/138119077/14cb3225-197a-4678-b926-2f51b2c35b38" /> |


## View Storybook

https://62eab350a45bdb0a5818520e-nhasrpmivp.chromatic.com/?path=/story/ion-navigation-steps--vertical

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.

the functionality was also validated in the Caná system to ensure that this change did not affect existing projects