### PR TITLE
refactor: adjust the default reference of the triple-toggle component

### DIFF
--- a/projects/ion/src/lib/triple-toggle/triple-toggle.component.spec.ts
+++ b/projects/ion/src/lib/triple-toggle/triple-toggle.component.spec.ts
@@ -1,10 +1,22 @@
-import { SimpleChange } from '@angular/core';
+import { Component, SimpleChange } from '@angular/core';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { TripleToggleProps } from '../core/types';
 import { IonSharedModule } from '../shared.module';
 import { IonTooltipModule } from '../tooltip/tooltip.module';
 import { SafeAny } from '../utils/safe-any';
 import { IonTripleToggleComponent } from './triple-toggle.component';
+import userEvent from '@testing-library/user-event';
+
+@Component({
+  template: `
+    <div>
+      <ion-triple-toggle data-testid="first-triple-toggle"></ion-triple-toggle>
+      <ion-triple-toggle data-testid="second-triple-toggle"></ion-triple-toggle>
+    </div>
+  `,
+  selector: 'test-multiple-triple-toggle',
+})
+class MultipleTripleToggleComponent {}
 
 const tripleToggleId = 'ion-triple-toggle';
 const firstOptionId = 'btn-Sim';
@@ -130,4 +142,24 @@ describe('IonTripleToggleComponent', () => {
     fireEvent.click(middleOption);
     clickEvent.mockClear();
   });
+});
+
+describe('MultipleTripleToggleComponent', () => {
+  const options = [firstOptionId, middleOptionId, lastOptionId];
+
+  it.each(options)(
+    'should select %s from the first triple Toggle, without modifying the second tripleToggle',
+    async (btns) => {
+      await render(MultipleTripleToggleComponent, {
+        declarations: [IonTripleToggleComponent],
+        imports: [IonSharedModule, IonTooltipModule],
+      });
+      const btnNeltralSecond = screen.getAllByRole('button')[4];
+      const [btn1] = screen.getAllByTestId(btns);
+
+      await userEvent.click(btn1);
+      expect(btn1).toHaveClass(selectedOption);
+      expect(btnNeltralSecond).toHaveClass(selectedOption);
+    }
+  );
 });

--- a/projects/ion/src/lib/triple-toggle/triple-toggle.component.ts
+++ b/projects/ion/src/lib/triple-toggle/triple-toggle.component.ts
@@ -31,6 +31,9 @@ export class IonTripleToggleComponent implements OnInit, OnChanges {
   @Input() onlyShowIcon = false;
   @Output() ionClick = new EventEmitter();
 
+  public optionsToRender: TripleToggleOptionsToRender;
+  public middleOptionIndex = 1;
+
   private DEFAULT_LEFT_OPTION: TripleToggleOption = {
     value: true,
     label: 'Sim',
@@ -44,9 +47,6 @@ export class IonTripleToggleComponent implements OnInit, OnChanges {
     value: false,
     label: 'Não',
   };
-
-  public optionsToRender: TripleToggleOptionsToRender;
-  public middleOptionIndex = 1;
 
   handleClick(option: TripleToggleOption): void {
     this.selectOption(option);

--- a/projects/ion/src/lib/triple-toggle/triple-toggle.component.ts
+++ b/projects/ion/src/lib/triple-toggle/triple-toggle.component.ts
@@ -17,19 +17,6 @@ import { SafeAny } from '../utils/safe-any';
 
 const FIRST_INDEX = 0;
 const SECOND_INDEX = 1;
-const DEFAULT_LEFT_OPTION: TripleToggleOption = {
-  value: true,
-  label: 'Sim',
-};
-const DEFAULT_MIDDLE_OPTION: TripleToggleOption = {
-  value: undefined,
-  label: '-',
-  selected: true,
-};
-const DEFAULT_RIGHT_OPTION: TripleToggleOption = {
-  value: false,
-  label: 'Não',
-};
 
 @Component({
   selector: 'ion-triple-toggle',
@@ -43,6 +30,20 @@ export class IonTripleToggleComponent implements OnInit, OnChanges {
   @Input() options: TripleToggleOptions;
   @Input() onlyShowIcon = false;
   @Output() ionClick = new EventEmitter();
+
+  private DEFAULT_LEFT_OPTION: TripleToggleOption = {
+    value: true,
+    label: 'Sim',
+  };
+  private DEFAULT_MIDDLE_OPTION: TripleToggleOption = {
+    value: undefined,
+    label: '-',
+    selected: true,
+  };
+  private DEFAULT_RIGHT_OPTION: TripleToggleOption = {
+    value: false,
+    label: 'Não',
+  };
 
   public optionsToRender: TripleToggleOptionsToRender;
   public middleOptionIndex = 1;
@@ -92,13 +93,13 @@ export class IonTripleToggleComponent implements OnInit, OnChanges {
     this.optionsToRender = [
       this.options && this.options[FIRST_INDEX]
         ? this.options[FIRST_INDEX]
-        : DEFAULT_LEFT_OPTION,
+        : this.DEFAULT_LEFT_OPTION,
 
-      DEFAULT_MIDDLE_OPTION,
+      this.DEFAULT_MIDDLE_OPTION,
 
       this.options && this.options[SECOND_INDEX]
         ? this.options[SECOND_INDEX]
-        : DEFAULT_RIGHT_OPTION,
+        : this.DEFAULT_RIGHT_OPTION,
     ];
   }
 }


### PR DESCRIPTION
## Adjust the default reference of the triple-toggle component #1042 
Currently, the triple-toggle component includes constants storing default values used for visual validation. Consequently, when two or more triple-toggle components are rendered on the same screen, the selected value is changed in all references. The issue has been addressed with a correction.
