### PR TITLE
feat: popover without header

### DIFF
--- a/projects/ion/src/lib/popover/component/popover.component.html
+++ b/projects/ion/src/lib/popover/component/popover.component.html
@@ -3,6 +3,7 @@
     ionPopoverCustomClass + ' ion-popover__sup-container--' + ionPopoverPosition
   "
   [class.ion-popover--visible]="ionPopoverVisible"
+  [class.without-header]="!ionPopoverTitle"
   data-testid="ion-popover"
   [style.top]="top + 'px'"
   [style.left]="left + 'px'"
@@ -11,7 +12,11 @@
   #popover
 >
   <div class="ion-popover__container">
-    <div class="ion-popover__header">
+    <div
+      data-testid="popover-header"
+      class="ion-popover__header"
+      *ngIf="ionPopoverTitle"
+    >
       <div>
         <ion-icon
           *ngIf="ionPopoverIcon"

--- a/projects/ion/src/lib/popover/component/popover.component.scss
+++ b/projects/ion/src/lib/popover/component/popover.component.scss
@@ -17,6 +17,10 @@ $arrow-distance-to-border: 16px;
   position: relative;
   z-index: $zIndexMid;
 
+  &.without-header::before {
+    background-color: #fff;
+  }
+
   @if ($position == 'header') {
     &::before {
       content: '';
@@ -253,25 +257,6 @@ $arrow-distance-to-border: 16px;
     color: $neutral-6;
     max-height: 92px;
     overflow-y: auto;
-
-    scrollbar-width: thin;
-    scrollbar-color: $primary-color;
-
-    // Chrome, Edge, and Safari
-    &::-webkit-scrollbar {
-      width: 8px;
-      height: 9px;
-    }
-
-    &::-webkit-scrollbar-track {
-      background: #ffffff;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      background-color: $neutral-2;
-      border-radius: 20px;
-      border: 3px solid $neutral-2;
-    }
   }
 
   &__footer {
@@ -280,4 +265,38 @@ $arrow-distance-to-border: 16px;
     padding: spacing(1) spacing(2) spacing(2) spacing(2);
     justify-content: flex-end;
   }
+}
+
+.without-header {
+  & .ion-popover__container {
+    padding: 16px 4px 16px 16px;
+  }
+
+  & .ion-popover__content-body {
+    border-radius: spacing(1);
+    padding: 0 8px 0 0;
+  }
+
+  &:has(.ion-popover__footer) {
+    .ion-popover__container {
+      padding: 0;
+    }
+
+    .ion-popover__content-body {
+      padding: 16px;
+    }
+  }
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 20px;
+  background: $neutral-5;
 }

--- a/projects/ion/src/lib/popover/component/popover.component.scss
+++ b/projects/ion/src/lib/popover/component/popover.component.scss
@@ -283,7 +283,7 @@ $arrow-distance-to-border: 16px;
     }
 
     .ion-popover__content-body {
-      padding: 16px;
+      padding: 16px 16px 12px;
     }
   }
 }

--- a/projects/ion/src/lib/popover/component/popover.component.spec.ts
+++ b/projects/ion/src/lib/popover/component/popover.component.spec.ts
@@ -84,6 +84,12 @@ describe('PopoverComponent', () => {
         screen.getByText(PopoverComponent.args.ionPopoverBody)
       ).toBeInTheDocument();
     });
+
+    it('should not render the header when the title is not informed', () => {
+      PopoverComponent.args.ionPopoverTitle = '';
+      fixture.detectChanges();
+      expect(screen.queryByTestId('popover-header')).not.toBeInTheDocument();
+    });
   });
 
   describe('with actions', () => {

--- a/stories/Popover.stories.ts
+++ b/stories/Popover.stories.ts
@@ -80,6 +80,18 @@ DirectiveWithTriggerHover.args = {
   ionPopoverArrowPointAtCenter: true,
 };
 
+export const DirectiveWithoutHeader = Template.bind({});
+DirectiveWithoutHeader.args = {
+  ionPopoverTitle: '',
+  ionPopoverPosition: PopoverPosition.DEFAULT,
+  ionPopoverIconClose: false,
+  ionPopoverIcon: 'historic',
+  ionPopoverIconColor: '#282b33',
+  ionPopoverCustomClass: 'popover-custom-class',
+  ionPopoverTrigger: PopoverTrigger.DEFAULT,
+  ionPopoverArrowPointAtCenter: true,
+};
+
 const TemplateOpen: Story = (args) => ({
   props: args,
   template: `


### PR DESCRIPTION
## Issue Number

fix #1037 

## Description

Now when user doesnt provide a title to the popover it renders without the header and with a customized style.



## Proposed Changes

- Popover without the header;
- Scrollbar style fixed.

## Screenshots

![image](https://github.com/Brisanet/ion/assets/138060158/ca596c17-9b14-4eb8-930c-3aee767bd696)
![Captura de tela de 2024-04-11 13-47-12](https://github.com/Brisanet/ion/assets/138060158/1ad25775-c752-48ab-b39d-aaa00269674a)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.
