### PR TITLE
1081 feat prevent popover close on scroll

### DIFF
--- a/projects/ion/src/lib/core/types/indicator.ts
+++ b/projects/ion/src/lib/core/types/indicator.ts
@@ -1,6 +1,6 @@
 import { Type } from '@angular/core';
 import { IonModalConfiguration } from '../../modal/models/modal.interface';
-import { PopoverProps } from './popover';
+import { PopoverDirectiveProps } from './popover';
 import { IonIconProps } from './icon';
 
 export enum IonIndicatorButtonType {
@@ -81,7 +81,7 @@ export interface IonIndicatorButtonConfiguration {
   popoverConfig?: PopoverConfig;
 }
 
-export interface PopoverConfig extends PopoverProps {
+export interface PopoverConfig extends PopoverDirectiveProps {
   firstAction?: () => void;
   secondAction?: () => void;
 }

--- a/projects/ion/src/lib/core/types/popover.ts
+++ b/projects/ion/src/lib/core/types/popover.ts
@@ -40,6 +40,7 @@ export interface PopoverProps {
   ionPopoverPosition?: PopoverPosition;
   ionPopoverKeep?: boolean;
   ionPopoverCustomClass?: string;
+  ionPopoverStopCloseOnScroll?: boolean;
   ionPopoverClose?: Subject<void>;
   ionOnFirstAction?: EventEmitter<void>;
   ionOnSecondAction?: EventEmitter<void>;

--- a/projects/ion/src/lib/core/types/popover.ts
+++ b/projects/ion/src/lib/core/types/popover.ts
@@ -40,14 +40,14 @@ export interface PopoverProps {
   ionPopoverPosition?: PopoverPosition;
   ionPopoverKeep?: boolean;
   ionPopoverCustomClass?: string;
-  ionPopoverStopCloseOnScroll?: boolean;
-  ionPopoverClose?: Subject<void>;
   ionOnFirstAction?: EventEmitter<void>;
   ionOnSecondAction?: EventEmitter<void>;
   ionOnClose?: EventEmitter<void>;
 }
 
 export interface PopoverDirectiveProps extends PopoverProps {
+  ionPopoverStopCloseOnScroll?: boolean;
+  ionPopoverClose?: Subject<void>;
   ionPopoverArrowPointAtCenter?: boolean;
   ionPopoverTrigger?: PopoverTrigger;
 }

--- a/projects/ion/src/lib/indicator/indicator.component.html
+++ b/projects/ion/src/lib/indicator/indicator.component.html
@@ -117,6 +117,9 @@
           [ionPopoverCustomClass]="
             buttonConfig.popoverConfig.ionPopoverCustomClass
           "
+          [ionPopoverStopCloseOnScroll]="
+            buttonConfig.popoverConfig.ionPopoverStopCloseOnScroll
+          "
           (ionOnFirstAction)="buttonConfig.popoverConfig.firstAction()"
           (ionOnSecondAction)="buttonConfig.popoverConfig.secondAction()"
         ></ion-button>

--- a/projects/ion/src/lib/popover/popover.directive.spec.ts
+++ b/projects/ion/src/lib/popover/popover.directive.spec.ts
@@ -59,6 +59,7 @@ const CUSTOM_CLASS = 'custom-class';
       [ionPopoverPosition]="ionPopoverPosition"
       [ionPopoverActions]="ionPopoverActions"
       [ionPopoverTrigger]="ionPopoverTrigger"
+      [ionPopoverStopCloseOnScroll]="ionPopoverStopCloseOnScroll"
       (ionOnFirstAction)="ionOnFirstAction()"
       (ionOnSecondAction)="ionOnSecondAction()"
       ionPopoverCustomClass="${CUSTOM_CLASS}"
@@ -82,6 +83,7 @@ class HostTestComponent {
   @Input() ionPopoverKeep = false;
   @Input() ionPopoverIconClose = true;
   @Input() ionPopoverIcon = 'condominium';
+  @Input() ionPopoverStopCloseOnScroll = false;
   @Input() ionPopoverActions: PopoverButtonsProps[] = [
     { label: 'action 1' },
     { label: 'action 2' },
@@ -309,6 +311,19 @@ describe('Directive: popover', () => {
     fireEvent.wheel(hostElement);
     expect(directive.onScroll).toBeCalled();
     expect(screen.queryByTestId('ion-popover')).not.toBeInTheDocument();
+  });
+
+  it('should not close the popover on scroll when its informed', async () => {
+    await sut({
+      ionPopoverStopCloseOnScroll: true,
+    });
+    const directive = IonPopoverDirective.prototype;
+    jest.spyOn(directive, 'onScroll');
+    const hostElement = screen.getByTestId('hostPopover');
+    fireEvent.click(hostElement);
+    fireEvent.wheel(hostElement);
+    expect(directive.onScroll).toBeCalled();
+    expect(screen.queryByTestId('ion-popover')).toBeVisible();
   });
 
   describe('trigger: hover', () => {

--- a/projects/ion/src/lib/popover/popover.directive.ts
+++ b/projects/ion/src/lib/popover/popover.directive.ts
@@ -45,6 +45,9 @@ export class IonPopoverDirective implements OnDestroy {
   @Input() ionPopoverTrigger: PopoverDirectiveProps['ionPopoverTrigger'] =
     PopoverTrigger.DEFAULT;
   @Input() ionPopoverClose?: PopoverDirectiveProps['ionPopoverClose'];
+  @Input()
+  ionPopoverStopCloseOnScroll: PopoverDirectiveProps['ionPopoverStopCloseOnScroll'] =
+    false;
   @Output() ionOnFirstAction: PopoverDirectiveProps['ionOnFirstAction'] =
     new EventEmitter<void>();
   @Output() ionOnSecondAction: PopoverDirectiveProps['ionOnSecondAction'] =
@@ -216,6 +219,7 @@ export class IonPopoverDirective implements OnDestroy {
   onScroll(event: Event): void {
     const targetElement = event.target;
     if (
+      !this.ionPopoverStopCloseOnScroll &&
       targetElement instanceof HTMLElement &&
       !targetElement.closest('ion-popover')
     ) {


### PR DESCRIPTION
## Issue Number

fix #1081 

## Description

It was added a new Input property "ionPopoverStopCloseOnScroll" to the ion Popover, so user is able to tell if it should not close when scrolling. The indicator was also updated, beeing added the property there.

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.