### PR TITLE
1086 feat disabled date range on date picker

### DIFF
--- a/projects/ion/src/lib/core/types/datepicker.ts
+++ b/projects/ion/src/lib/core/types/datepicker.ts
@@ -2,10 +2,16 @@ import { EventEmitter } from '@angular/core';
 
 type FormatDateInput = 'YYYY-MM-DD' | 'DD/MM/YYYY';
 
+export enum CalendarDirection {
+  up = 'UP',
+  down = 'DOWN',
+}
+
 export interface IonDatePickerComponentProps {
   format?: string;
   formatInDateInput?: FormatDateInput;
   rangePicker?: boolean;
+  direction?: CalendarDirection;
   disabledDate?: (currentDate: Date) => boolean;
   event?: EventEmitter<string>;
 }

--- a/projects/ion/src/lib/core/types/datepicker.ts
+++ b/projects/ion/src/lib/core/types/datepicker.ts
@@ -3,8 +3,10 @@ import { EventEmitter } from '@angular/core';
 type FormatDateInput = 'YYYY-MM-DD' | 'DD/MM/YYYY';
 
 export enum CalendarDirection {
-  up = 'UP',
-  down = 'DOWN',
+  topLeft = 'TOPLEFT',
+  topRight = 'TOPRIGHT',
+  bottomLeft = 'BOTTOMLEFT',
+  bottomRight = 'BOTTOMRIGHT',
 }
 
 export interface IonDatePickerComponentProps {

--- a/projects/ion/src/lib/core/types/datepicker.ts
+++ b/projects/ion/src/lib/core/types/datepicker.ts
@@ -6,5 +6,6 @@ export interface IonDatePickerComponentProps {
   format?: string;
   formatInDateInput?: FormatDateInput;
   rangePicker?: boolean;
+  disabledDate?: (currentDate: Date) => boolean;
   event?: EventEmitter<string>;
 }

--- a/projects/ion/src/lib/picker/core/calendar-model.ts
+++ b/projects/ion/src/lib/picker/core/calendar-model.ts
@@ -19,5 +19,6 @@ export interface IonDatePickerCalendarComponentProps {
   goToYearInCalendar?: string;
   calendarControlAction?: CalendarControlActions;
   rangePicker?: boolean;
+  disabledDate?: (currentDate: Date) => boolean;
   events?: EventEmitter<[Day, Day]>;
 }

--- a/projects/ion/src/lib/picker/core/day.ts
+++ b/projects/ion/src/lib/picker/core/day.ts
@@ -15,6 +15,8 @@ export class Day {
   monthNumber: number;
   timestamp: number;
   week: number;
+  disabled?: boolean;
+  isDayCurrentMonth?: boolean;
   isToday?: boolean;
   isBetweenRange?: boolean;
   isRangeInitialLimit?: boolean;

--- a/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.html
+++ b/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.html
@@ -11,6 +11,7 @@
       [class.between-range]="day.isBetweenRange"
       [class.initial]="day.isRangeInitialLimit"
       [class.final]="day.isRangeFinalLimit"
+      [class.disabled]="day.disabled"
     >
       <button
         [attr.data-testid]="day.getAriaLabel()"

--- a/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.scss
+++ b/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.scss
@@ -102,5 +102,19 @@
         margin-right: 13px;
       }
     }
+
+    .disabled,
+    .disabled button {
+      width: 100%;
+      background-color: $neutral-3 !important;
+      color: $neutral-5;
+      cursor: not-allowed;
+
+      &:hover {
+        background-color: $neutral-3 !important;
+        cursor: not-allowed;
+        color: $neutral-5;
+      }
+    }
   }
 }

--- a/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.spec.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.spec.ts
@@ -9,6 +9,12 @@ import { SimpleChange, SimpleChanges } from '@angular/core';
 import { Day } from '../../core/day';
 import { arrangeDates } from '../../../utils/datePicker';
 
+const mockDisableFutureDate = jest
+  .fn()
+  .mockImplementation((currrDate: Date) => {
+    const today = new Date();
+    return currrDate > today;
+  });
 const events = jest.fn();
 
 const defaultComponent: IonDatePickerCalendarComponentProps = {
@@ -107,6 +113,28 @@ describe('IonDatePickerCalendarComponent', () => {
     const buttonsDay = document.getElementsByClassName('month-day');
     fireEvent.click(buttonsDay[0]);
     expect(clickEvent).toHaveBeenCalled();
+  });
+
+  it('should disable only day buttons that match the rule of disabledDate', async () => {
+    await sut({
+      disabledDate: mockDisableFutureDate,
+    });
+    expect(screen.getByTestId('container-2024-05-02')).not.toHaveClass(
+      'disabled'
+    );
+    expect(screen.getByTestId('container-2024-05-03')).toHaveClass('disabled');
+  });
+
+  it('should not fire an event when clicking a disabled day button', async () => {
+    const clickEvent = jest.fn();
+    await sut({
+      disabledDate: mockDisableFutureDate,
+      events: {
+        emit: clickEvent,
+      } as SafeAny,
+    });
+    fireEvent.click(screen.getByTestId('2024-05-03'));
+    expect(clickEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.spec.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.spec.ts
@@ -12,8 +12,8 @@ import { arrangeDates } from '../../../utils/datePicker';
 const mockDisableFutureDate = jest
   .fn()
   .mockImplementation((currrDate: Date) => {
-    const today = new Date();
-    return currrDate > today;
+    const mockPresentDay = new Date('2024-05-02T03:00:00');
+    return currrDate > mockPresentDay;
   });
 const events = jest.fn();
 
@@ -117,6 +117,7 @@ describe('IonDatePickerCalendarComponent', () => {
 
   it('should disable only day buttons that match the rule of disabledDate', async () => {
     await sut({
+      currentDate: ['2024-05-02'],
       disabledDate: mockDisableFutureDate,
     });
     expect(screen.getByTestId('container-2024-05-02')).not.toHaveClass(
@@ -128,6 +129,7 @@ describe('IonDatePickerCalendarComponent', () => {
   it('should not fire an event when clicking a disabled day button', async () => {
     const clickEvent = jest.fn();
     await sut({
+      currentDate: ['2024-05-02'],
       disabledDate: mockDisableFutureDate,
       events: {
         emit: clickEvent,

--- a/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.ts
@@ -103,10 +103,11 @@ export class IonDatePickerCalendarComponent implements OnInit, OnChanges {
   }
 
   handleClick(dayIndex: number): void {
+    if (this.days[dayIndex].disabled) {
+      return;
+    }
+
     if (this.rangePicker) {
-      if (this.days[dayIndex].disabled) {
-        return;
-      }
       if (!this.selectedDays.length || this.selectedDays[FINAL_RANGE]) {
         this.selectedDays = [this.days[dayIndex]];
         return;

--- a/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.ts
@@ -21,7 +21,6 @@ import {
   SUNDAY,
   TOTAL_DAYS,
 } from '../../../utils';
-import { SafeAny } from '../../../utils/safe-any';
 import { Calendar } from '../../core/calendar';
 import {
   CalendarControlActions,
@@ -54,6 +53,7 @@ export class IonDatePickerCalendarComponent implements OnInit, OnChanges {
   @Input() calendarControlAction: CalendarControlActions;
   @Input() selectedDays: Day[] = [];
   @Input() rangePicker: boolean;
+  @Input() disabledDate?: IonDatePickerCalendarComponentProps['disabledDate'];
   @Output() events = new EventEmitter<[Day, Day]>();
   @Output() updateLabelCalendar = new EventEmitter<UpdateLabelCalendar>();
   public days: Day[] = [];
@@ -104,6 +104,9 @@ export class IonDatePickerCalendarComponent implements OnInit, OnChanges {
 
   handleClick(dayIndex: number): void {
     if (this.rangePicker) {
+      if (this.days[dayIndex].disabled) {
+        return;
+      }
       if (!this.selectedDays.length || this.selectedDays[FINAL_RANGE]) {
         this.selectedDays = [this.days[dayIndex]];
         return;
@@ -132,11 +135,14 @@ export class IonDatePickerCalendarComponent implements OnInit, OnChanges {
   tempRenderDays(): void {
     this.days = this.getMonthDaysGrid();
     this.days.map((day) => {
-      (day as SafeAny).isDayCurrentMonth = this.isDayMonthCurrent(day);
+      day.isDayCurrentMonth = this.isDayMonthCurrent(day);
       day.isToday = isToday(day, this.lang);
       day.isBetweenRange = isBetweenRange(day, this.selectedDays);
       day.isRangeInitialLimit = this.isRangeLimit(day);
       day.isRangeFinalLimit = this.isRangeLimit(day, this.finalRange);
+      if (this.disabledDate) {
+        day.disabled = this.disabledDate(day.Date);
+      }
     });
 
     setTimeout(() => {

--- a/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker-calendar/date-picker-calendar.component.ts
@@ -53,7 +53,7 @@ export class IonDatePickerCalendarComponent implements OnInit, OnChanges {
   @Input() calendarControlAction: CalendarControlActions;
   @Input() selectedDays: Day[] = [];
   @Input() rangePicker: boolean;
-  @Input() disabledDate?: IonDatePickerCalendarComponentProps['disabledDate'];
+  @Input() disabledDate: IonDatePickerCalendarComponentProps['disabledDate'];
   @Output() events = new EventEmitter<[Day, Day]>();
   @Output() updateLabelCalendar = new EventEmitter<UpdateLabelCalendar>();
   public days: Day[] = [];

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.html
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.html
@@ -5,9 +5,7 @@
   (clearDate)="clearDate()"
 ></date-picker-input>
 <div
-  class="container-calendar"
-  [class.calendar-down]="direction === 'DOWN'"
-  [class.calendar-up]="direction === 'UP'"
+  [class]="'container-calendar container-calendar--' + direction"
   *ngIf="showDatepicker"
   data-testid="container-calendar"
 >

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.html
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.html
@@ -25,6 +25,7 @@
         [currentDate]="currentDate"
         [rangePicker]="rangePicker"
         [selectedDays]="selectedDay"
+        [disabledDate]="disabledDate"
         (updateLabelCalendar)="updateLabelCalendar($event)"
         (events)="dateSelected($event)"
       ></date-picker-calendar>

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.html
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.html
@@ -6,6 +6,8 @@
 ></date-picker-input>
 <div
   class="container-calendar"
+  [class.calendar-down]="direction === 'DOWN'"
+  [class.calendar-up]="direction === 'UP'"
   *ngIf="showDatepicker"
   data-testid="container-calendar"
 >

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.scss
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.scss
@@ -18,12 +18,22 @@
   background-color: $neutral-1;
   border-radius: 8px;
 
-  &.calendar-down {
+  &--BOTTOMLEFT {
     top: 100%;
   }
 
-  &.calendar-up {
+  &--BOTTOMRIGHT {
+    top: 100%;
+    right: 0;
+  }
+
+  &--TOPLEFT {
     bottom: 100%;
+  }
+
+  &--TOPRIGHT {
+    bottom: 100%;
+    right: 0;
   }
 
   .container-body {

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.scss
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.scss
@@ -1,16 +1,30 @@
 @import '../../../styles/index.scss';
 
+:host {
+  position: relative;
+}
+
 * {
   box-sizing: border-box;
 }
 
 .container-calendar {
+  position: absolute;
+  z-index: $zIndexMax;
   max-width: 312px;
   min-width: 312px;
   margin: spacing(1) spacing(0);
   border: 1px solid $neutral-4;
   background-color: $neutral-1;
   border-radius: 8px;
+
+  &.calendar-down {
+    top: 100%;
+  }
+
+  &.calendar-up {
+    bottom: 100%;
+  }
 
   .container-body {
     padding: spacing(3) spacing(3) spacing(3);

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.spec.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { screen } from '@testing-library/angular';
+
 import { SafeAny } from '../../utils/safe-any';
 import {
   ControlEvent,
@@ -14,6 +16,7 @@ import {
 } from './date-picker.component';
 import { IonDatePickerModule } from './date-picker.module';
 import { calculateDuration } from '../../utils';
+import { CalendarDirection } from '../../core/types/datepicker';
 
 const previouslyRangeDates = [
   { label: 'Last 7 days', duration: 'P7D', isFuture: false },
@@ -26,6 +29,8 @@ const posteriorlyRangeDates = [
   { label: 'Next 15 days', duration: 'P15D', isFuture: true },
   { label: 'Next 31 days', duration: 'P31D', isFuture: true },
 ];
+
+const calendarDirections = Object.values(CalendarDirection);
 
 describe('DatePickerCalendar', () => {
   let component: IonDatepickerComponent;
@@ -108,6 +113,19 @@ describe('DatePickerCalendar', () => {
       }, 0);
     }
   );
+
+  it.each(calendarDirections)(
+    'should render in the %s position',
+    async (containerClass) => {
+      component.direction = containerClass;
+      component.showDatepicker = true;
+      fixture.detectChanges();
+      expect(screen.getByTestId('container-calendar')).toHaveClass(
+        `container-calendar--${containerClass}`
+      );
+    }
+  );
+
   describe('PreDefinedRangePicker', () => {
     const today = new Date().getTime();
     describe.each(previouslyRangeDates)('Previously Dates', (range) => {

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.ts
@@ -32,6 +32,7 @@ export class IonDatepickerComponent implements AfterViewInit {
     DEFAULT_INPUT_FORMAT;
   @Input() rangePicker: boolean;
   @Input() predefinedRanges?: PreDefinedRangeConfig[] = [];
+  @Input() disabledDate?: IonDatePickerComponentProps['disabledDate'];
   @Output() event = new EventEmitter<string[]>();
   currentDate: string[];
   inputDate: string;

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.ts
@@ -36,7 +36,7 @@ export class IonDatepickerComponent implements AfterViewInit {
   @Input() rangePicker: boolean;
   @Input() predefinedRanges?: PreDefinedRangeConfig[] = [];
   @Input() direction?: IonDatePickerComponentProps['direction'] =
-    CalendarDirection.down;
+    CalendarDirection.bottomLeft;
   @Input() disabledDate?: IonDatePickerComponentProps['disabledDate'];
   @Output() event = new EventEmitter<string[]>();
   currentDate: string[];

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.ts
@@ -5,7 +5,10 @@ import {
   Input,
   Output,
 } from '@angular/core';
-import { IonDatePickerComponentProps } from '../../core/types/datepicker';
+import {
+  CalendarDirection,
+  IonDatePickerComponentProps,
+} from '../../core/types/datepicker';
 import { SafeAny } from '../../utils/safe-any';
 import { ControlEvent } from '../control-picker/control-picker.component';
 import { UpdateLabelCalendar } from '../core/calendar-model';
@@ -32,6 +35,8 @@ export class IonDatepickerComponent implements AfterViewInit {
     DEFAULT_INPUT_FORMAT;
   @Input() rangePicker: boolean;
   @Input() predefinedRanges?: PreDefinedRangeConfig[] = [];
+  @Input() direction?: IonDatePickerComponentProps['direction'] =
+    CalendarDirection.down;
   @Input() disabledDate?: IonDatePickerComponentProps['disabledDate'];
   @Output() event = new EventEmitter<string[]>();
   currentDate: string[];

--- a/projects/ion/src/lib/picker/date-picker/date-picker.component.ts
+++ b/projects/ion/src/lib/picker/date-picker/date-picker.component.ts
@@ -35,9 +35,9 @@ export class IonDatepickerComponent implements AfterViewInit {
     DEFAULT_INPUT_FORMAT;
   @Input() rangePicker: boolean;
   @Input() predefinedRanges?: PreDefinedRangeConfig[] = [];
-  @Input() direction?: IonDatePickerComponentProps['direction'] =
+  @Input() direction: IonDatePickerComponentProps['direction'] =
     CalendarDirection.bottomLeft;
-  @Input() disabledDate?: IonDatePickerComponentProps['disabledDate'];
+  @Input() disabledDate: IonDatePickerComponentProps['disabledDate'];
   @Output() event = new EventEmitter<string[]>();
   currentDate: string[];
   inputDate: string;

--- a/stories/Datepicker.stories.ts
+++ b/stories/Datepicker.stories.ts
@@ -5,6 +5,7 @@ import { Meta, Story } from '@storybook/angular/types-6-0';
 import { IonTooltipComponent } from '../projects/ion/src/lib/tooltip/tooltip.component';
 import { IonDatePickerModule } from '../projects/ion/src/public-api';
 import { IonDatepickerComponent } from './../projects/ion/src/lib/picker/date-picker/date-picker.component';
+import { CalendarDirection } from '../projects/ion/src/lib/core/types/datepicker';
 
 const disabledDate = (currDate: Date): boolean => {
   const today = new Date();
@@ -40,11 +41,16 @@ RangePicker.args = {
 
 export const RangerPickerWithPeriods = Template.bind({});
 RangerPickerWithPeriods.args = {
-  disabledDate,
   rangePicker: true,
   predefinedRanges: [
     { label: 'Últimos 7 dias', duration: 'P7D' },
     { label: 'Últimos 15 dias', duration: 'P15D' },
     { label: 'Últimos 30 dias', duration: 'P30D' },
   ],
+};
+
+export const WithDisabledDate = Template.bind({});
+WithDisabledDate.args = {
+  disabledDate,
+  direction: CalendarDirection.bottomLeft,
 };

--- a/stories/Datepicker.stories.ts
+++ b/stories/Datepicker.stories.ts
@@ -6,6 +6,11 @@ import { IonTooltipComponent } from '../projects/ion/src/lib/tooltip/tooltip.com
 import { IonDatePickerModule } from '../projects/ion/src/public-api';
 import { IonDatepickerComponent } from './../projects/ion/src/lib/picker/date-picker/date-picker.component';
 
+const disabledDate = (currDate: Date): boolean => {
+  const today = new Date();
+  return currDate > today;
+};
+
 export default {
   title: 'Ion/Data Entry/Datepicker',
   component: IonDatepickerComponent,
@@ -35,6 +40,7 @@ RangePicker.args = {
 
 export const RangerPickerWithPeriods = Template.bind({});
 RangerPickerWithPeriods.args = {
+  disabledDate,
   rangePicker: true,
   predefinedRanges: [
     { label: 'Últimos 7 dias', duration: 'P7D' },


### PR DESCRIPTION
## Issue Number

fix #1086 

## Description

User now can disable dates based on a rule that can be specified in a function to be passed to the date-picker component. This function has a "currentDate" parameter that represents the day that is beeing compared to return a boolean resulting from a check if either it will be disabled or not.
The position that the calendar was beeing reendered was also fixed, given user now 4 options of positioning.

## Screenshots

![image](https://github.com/Brisanet/ion/assets/138060158/7151fa94-c440-4c33-ae40-db238baf36b7)

## View Storybook

[Story](https://62eab350a45bdb0a5818520e-nschehsddo.chromatic.com/?path=/story/ion-data-entry-datepicker--with-disabled-date)

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.
