### PR TITLE
feat: popconfirm close on scroll

### DIFF
--- a/projects/ion/src/lib/core/types/popconfirm.ts
+++ b/projects/ion/src/lib/core/types/popconfirm.ts
@@ -6,4 +6,5 @@ export interface PopConfirmProps {
   ionPopConfirmDesc?: string;
   ionConfirmText?: string;
   ionCancelText?: string;
+  ionPopConfirmCloseOnScroll?: boolean;
 }

--- a/projects/ion/src/lib/popconfirm/mock/open-popconfirm.component.ts
+++ b/projects/ion/src/lib/popconfirm/mock/open-popconfirm.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 @Component({
   template: `
@@ -13,6 +13,7 @@ import { Component } from '@angular/core';
       <ion-button
         label="Open Popconfirm"
         ionPopConfirm
+        [ionPopConfirmCloseOnScroll]="ionPopConfirmCloseOnScroll"
         ionConfirmText="Sim"
         ionCancelText="Não"
       >
@@ -20,4 +21,6 @@ import { Component } from '@angular/core';
     </div>
   `,
 })
-export class OpenPopconfirmComponent {}
+export class OpenPopconfirmComponent {
+  @Input() ionPopConfirmCloseOnScroll = false;
+}

--- a/projects/ion/src/lib/popconfirm/popconfirm.directive.spec.ts
+++ b/projects/ion/src/lib/popconfirm/popconfirm.directive.spec.ts
@@ -9,7 +9,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
-import { fireEvent, screen, within } from '@testing-library/angular';
+import { CommonModule } from '@angular/common';
+import {
+  RenderResult,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/angular';
 import { IonButtonModule } from '../button/button.module';
 import { IonDividerModule } from '../divider/divider.module';
 import { IonPopConfirmComponent } from './popconfirm.component';
@@ -18,6 +25,8 @@ import {
   PopOffset,
   PopPosition,
 } from './popconfirm.directive';
+import { OpenPopconfirmComponent } from './mock/open-popconfirm.component';
+import { IonPopConfirmModule } from './popconfirm.module';
 
 const textButton = 'Teste';
 const tableTextButton = 'Teste na table';
@@ -57,6 +66,7 @@ const openToUpOffset: PopOffset = {
       *ngIf="buttonVisibility"
       ionPopConfirm
       ionPopConfirmTitle="Você tem certeza?"
+      ionPopConfirmCloseOnScroll="true"
       (ionOnConfirm)="confirm()"
       class="get-test"
       style="margin-top: 50px;"
@@ -457,5 +467,34 @@ describe('Popconfirm position when it opens', () => {
 
     expect(spyAnimationFrame).toHaveBeenCalled();
     expect(spyQuerySelector).toHaveBeenCalledWith('.sup-container');
+  });
+});
+
+describe('Popconfirm close on scroll', () => {
+  const sut = async (
+    props: Partial<OpenPopconfirmComponent>
+  ): Promise<RenderResult<OpenPopconfirmComponent>> => {
+    return await render(OpenPopconfirmComponent, {
+      componentProperties: props,
+      imports: [CommonModule, IonPopConfirmModule, IonButtonModule],
+    });
+  };
+
+  it('should not close the popconfirm on scroll by default', async () => {
+    await sut({});
+    const hostElement = screen.getByTestId('btn-Open Popconfirm');
+    fireEvent.click(hostElement);
+    fireEvent.wheel(hostElement);
+    expect(screen.getByTestId('sup-container')).toBeVisible();
+  });
+
+  it('should close the popconfirm on scroll when informed', async () => {
+    await sut({
+      ionPopConfirmCloseOnScroll: true,
+    });
+    const hostElement = screen.getByTestId('btn-Open Popconfirm');
+    fireEvent.click(hostElement);
+    fireEvent.wheel(hostElement);
+    expect(screen.queryByTestId('sup-container')).not.toBeInTheDocument();
   });
 });

--- a/projects/ion/src/lib/popconfirm/popconfirm.directive.ts
+++ b/projects/ion/src/lib/popconfirm/popconfirm.directive.ts
@@ -41,6 +41,8 @@ export class IonPopConfirmDirective implements OnDestroy {
   @Input() ionPopConfirmType: StatusType = 'warning';
   @Input() ionConfirmText: PopConfirmProps['ionConfirmText'] = 'Confirmar';
   @Input() ionCancelText: PopConfirmProps['ionCancelText'] = 'Cancelar';
+  @Input()
+  ionPopConfirmCloseOnScroll: PopConfirmProps['ionPopConfirmCloseOnScroll'] = false;
   @Output() ionOnConfirm = new EventEmitter<void>();
   @Output() ionOnClose = new EventEmitter<void>();
 
@@ -243,6 +245,20 @@ export class IonPopConfirmDirective implements OnDestroy {
           this.setStyle(popconfirmElement, offsetPosition);
         }
       });
+    }
+  }
+
+  @HostListener('window:scroll', ['$event'])
+  @HostListener('document:scroll', ['$event'])
+  @HostListener('body:scroll', ['$event'])
+  @HostListener('window:wheel', ['$event'])
+  onScroll({ target }: Event): void {
+    if (
+      this.ionPopConfirmCloseOnScroll &&
+      target instanceof HTMLElement &&
+      !target.closest('ion-popconfirm')
+    ) {
+      this.closeAllPopsConfirm();
     }
   }
 }


### PR DESCRIPTION
## Issue Number

fix #1091 

## Description

It was required from the popconfirm to close on scroll, so it was added a listener and a input property to only close when it is informed.

## How to Test

yarn test popconfirm.directive

## View Storybook



## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.