### PR TITLE
fix: input select opening options when enter is pressed inside a form

### DIFF
--- a/projects/ion/src/lib/input-select/input-select.component.html
+++ b/projects/ion/src/lib/input-select/input-select.component.html
@@ -6,6 +6,7 @@
   >
     <div class="dropdown-container" (clickOutside)="onClickOutside()">
       <button
+        type="button"
         data-testid="ion-select-button"
         (click)="handleClick()"
         class="dropdown-container__button"


### PR DESCRIPTION
Prevents that the select is opened or closed when enter is pressed when ion-input-select is inside a form.