### PR TITLE
feat: empty cell on tag and link show config

### DIFF
--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -153,49 +153,57 @@
               #cell
             >
               <!-- cell types -->
-
-              <span class="td-span" *ngIf="!column.type">{{
-                row[column.key] | replaceEmpty: '-'
-              }}</span>
-              <ion-tag
-                *ngIf="column.type === 'tag'"
-                data-testid="tag-cell"
-                [label]="row[column.key]"
-                [status]="row[column.tag.statusKey] || column.tag.status"
-                [icon]="row[column.tag.iconKey] || column.tag.icon"
-                ionTooltip
-                [ionTooltipTitle]="
-                  row[column.tag.tooltipKey] || row[column.key]
-                "
-              ></ion-tag>
-              <ion-link
-                *ngIf="column.type === 'link' && column.link"
-                data-testid="link-element"
-                [label]="column.link.label(row)"
-                [icon]="column.link.icon"
-                [iconSide]="column.link.iconSide"
-                [size]="column.link.size || 'sm'"
-                [bold]="column.link.bold"
-                [disabled]="column.link.disabled && column.link.disabled(row)"
-                [target]="column.link.target"
-                [link]="column.link.url && column.link.url(row)"
-                ionTooltip
-                [ionTooltipTitle]="column.link.tooltipConfig?.text(row)"
-                [ionTooltipColorScheme]="
-                  column.link.tooltipConfig?.ionTooltipColorScheme || 'dark'
-                "
-                [ionTooltipPosition]="
-                  column.link.tooltipConfig?.ionTooltipPosition || 'topCenter'
-                "
-                [ionTooltipArrowPointAtCenter]="
-                  column.link.tooltipConfig?.ionTooltipArrowPointAtCenter ||
-                  true
-                "
-                [ionTooltipShowDelay]="
-                  column.link.tooltipConfig?.ionTooltipShowDelay || 0
-                "
-                (ionOnClick)="column.link.action(row)"
-              ></ion-link>
+              <span
+                class="td-span"
+                *ngIf="!column.type || column.type === 'text'"
+                >{{ row[column.key] | replaceEmpty: '-' }}</span
+              >
+              <ng-container *ngIf="column.type === 'tag'">
+                <ion-tag
+                  *ngIf="row[column.key]; else emptyCell"
+                  data-testid="tag-cell"
+                  [label]="row[column.key]"
+                  [status]="row[column.tag.statusKey] || column.tag.status"
+                  [icon]="row[column.tag.iconKey] || column.tag.icon"
+                  ionTooltip
+                  [ionTooltipTitle]="
+                    row[column.tag.tooltipKey] || row[column.key]
+                  "
+                ></ion-tag>
+              </ng-container>
+              <ng-container *ngIf="column.type === 'link' && column.link">
+                <ion-link
+                  *ngIf="
+                    !column.link.show || column.link.show(row);
+                    else emptyCell
+                  "
+                  data-testid="link-element"
+                  [label]="column.link.label(row)"
+                  [icon]="column.link.icon"
+                  [iconSide]="column.link.iconSide"
+                  [size]="column.link.size || 'sm'"
+                  [bold]="column.link.bold"
+                  [disabled]="column.link.disabled && column.link.disabled(row)"
+                  [target]="column.link.target"
+                  [link]="column.link.url && column.link.url(row)"
+                  ionTooltip
+                  [ionTooltipTitle]="column.link.tooltipConfig?.text(row)"
+                  [ionTooltipColorScheme]="
+                    column.link.tooltipConfig?.ionTooltipColorScheme || 'dark'
+                  "
+                  [ionTooltipPosition]="
+                    column.link.tooltipConfig?.ionTooltipPosition || 'topCenter'
+                  "
+                  [ionTooltipArrowPointAtCenter]="
+                    column.link.tooltipConfig?.ionTooltipArrowPointAtCenter ||
+                    true
+                  "
+                  [ionTooltipShowDelay]="
+                    column.link.tooltipConfig?.ionTooltipShowDelay || 0
+                  "
+                  (ionOnClick)="column.link.action(row)"
+                ></ion-link>
+              </ng-container>
               <span class="td-span" *ngIf="column.type === 'boolean'">
                 {{
                   row[column.key]
@@ -400,6 +408,10 @@
   <ng-template #noData>
     <ion-icon size="40" type="exclamation-rounded"></ion-icon>
     <span>Não há dados</span>
+  </ng-template>
+
+  <ng-template #emptyCell>
+    <span class="td-span"> - </span>
   </ng-template>
 
   <div

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -174,7 +174,7 @@
               <ng-container *ngIf="column.type === 'link' && column.link">
                 <ion-link
                   *ngIf="
-                    !column.link.show || column.link.show(row);
+                    !column.link.hide || !column.link.hide(row);
                     else emptyCell
                   "
                   data-testid="link-element"

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -757,6 +757,19 @@ describe('Table > Differents columns data type', () => {
         ).toHaveLength(1);
       }
     );
+
+    it('should show an empty cell when the data is undefined on a tag column', async () => {
+      const columns = tableDifferentColumns.config.columns;
+      const lastColumn = columns.length - 1;
+      const tagKey = 'notFound';
+      columns[lastColumn] = {
+        ...columns[lastColumn],
+        key: tagKey,
+      };
+      await sut(tableDifferentColumns);
+      const cell = screen.getByTestId(`row-0-${tagKey}`);
+      expect(cell).toHaveTextContent('-');
+    });
   });
 
   describe('Pipes', () => {
@@ -1637,6 +1650,31 @@ describe('Table > Link in cells', () => {
 
     fireEvent.mouseEnter(screen.getByTestId('link-element'));
     expect(screen.getByTestId('ion-tooltip')).toBeVisible();
+  });
+
+  it('should show an empty cell when the show function returns false', async () => {
+    await sut({
+      config: {
+        data: [{ ...dataWithLink[0], name: '' }],
+        columns: [
+          ...columns,
+          {
+            ...linkConfig,
+            link: {
+              ...linkConfig.link,
+              show: (row): boolean => !!row.name,
+            },
+          },
+        ],
+        pagination: {
+          total: 82,
+          itemsPerPage: 10,
+          page: 1,
+        },
+      },
+    });
+
+    expect(screen.getByTestId('row-0-url')).toHaveTextContent('-');
   });
 });
 

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -1662,7 +1662,7 @@ describe('Table > Link in cells', () => {
             ...linkConfig,
             link: {
               ...linkConfig.link,
-              show: (row): boolean => !!row.name,
+              hide: (row): boolean => !row.name,
             },
           },
         ],

--- a/projects/ion/src/lib/table/utilsTable.ts
+++ b/projects/ion/src/lib/table/utilsTable.ts
@@ -46,7 +46,7 @@ interface LinkRow<RowType> {
   url?: (_: RowType) => string;
   action?: (_: RowType) => void;
   tooltipConfig?: LinkTooltip<RowType>;
-  show?: (_: RowType) => boolean;
+  hide?: (_: RowType) => boolean;
 }
 
 interface LinkTooltip<RowType> extends Omit<TooltipProps, 'ionTooltipTitle'> {

--- a/projects/ion/src/lib/table/utilsTable.ts
+++ b/projects/ion/src/lib/table/utilsTable.ts
@@ -8,9 +8,9 @@ import {
   TooltipProps,
 } from '../core/types';
 import { SafeAny } from '../utils/safe-any';
+import { Omit } from '../utils/types';
 import { IconSide, LinkTarget } from './../core/types/link';
 import { TagStatus } from './../core/types/status';
-import { Omit } from '../utils/types';
 
 export enum EventTable {
   SORT = 'sort',
@@ -46,6 +46,7 @@ interface LinkRow<RowType> {
   url?: (_: RowType) => string;
   action?: (_: RowType) => void;
   tooltipConfig?: LinkTooltip<RowType>;
+  show?: (_: RowType) => boolean;
 }
 
 interface LinkTooltip<RowType> extends Omit<TooltipProps, 'ionTooltipTitle'> {


### PR DESCRIPTION
After this implementation, empty tags and empty links will look like this:

![Screenshot from 2024-07-24 12-03-43](https://github.com/user-attachments/assets/d5eb3933-3d52-4300-8746-8bcf1df5dff6)

I also fixed a bug where, when on config table we declare explicitly that type is 'text', nothing was displayed.