### PR TITLE
fix: add min max and disabled props to input counter

### DIFF
--- a/projects/ion/src/lib/core/types/input-counter.ts
+++ b/projects/ion/src/lib/core/types/input-counter.ts
@@ -2,4 +2,8 @@ export type InputCountSize = 'sm' | 'md';
 
 export interface IonInputCount {
   inputSize: InputCountSize;
+  minValue?: number;
+  maxValue?: number;
+  disabled?: boolean;
+  count?: number;
 }

--- a/projects/ion/src/lib/core/types/input-counter.ts
+++ b/projects/ion/src/lib/core/types/input-counter.ts
@@ -4,6 +4,7 @@ export interface IonInputCount {
   inputSize: InputCountSize;
   minValue?: number;
   maxValue?: number;
+  maxDigits?: number;
   disabled?: boolean;
   count?: number;
 }

--- a/projects/ion/src/lib/input-counter/input-counter.component.html
+++ b/projects/ion/src/lib/input-counter/input-counter.component.html
@@ -11,7 +11,7 @@
   <input
     type="text"
     data-testid="input-count"
-    maxlength="9"
+    [maxlength]="maxDigits"
     [value]="count"
     [(ngModel)]="count"
     [disabled]="disabled"

--- a/projects/ion/src/lib/input-counter/input-counter.component.html
+++ b/projects/ion/src/lib/input-counter/input-counter.component.html
@@ -1,5 +1,6 @@
 <div class="counter">
   <ion-button
+    [disabled]="disabled"
     data-testid="iconSub"
     iconType="sub"
     type="ghost"
@@ -9,14 +10,18 @@
 
   <input
     type="text"
-    oninput="this.value = this.value.replace(/[^0-9]/g, '').replace(/(\..*)\./g, '$1');"
-    [(ngModel)]="count"
     data-testid="input-count"
-    (ngModelChange)="changeCount($event)"
+    maxlength="9"
     [value]="count"
+    [(ngModel)]="count"
+    [disabled]="disabled"
+    (blur)="onBlurInput()"
+    (ngModelChange)="changeCount($event)"
+    oninput="this.value = this.value.replace(/[^0-9]/g, '').replace(/(\..*)\./g, '$1');"
   />
 
   <ion-button
+    [disabled]="disabled"
     data-testid="iconAdd"
     iconType="add"
     type="ghost"

--- a/projects/ion/src/lib/input-counter/input-counter.component.scss
+++ b/projects/ion/src/lib/input-counter/input-counter.component.scss
@@ -5,12 +5,22 @@
   border: 1px solid $neutral-5;
   border-radius: 6px;
 
+  ::ng-deep .ion-btn-ghost:disabled {
+    background-color: $neutral-2 !important;
+  }
+
   & input {
     border: none;
     outline: none;
     text-align: center;
     font-size: 12px;
     color: $neutral-5;
+
+    &:disabled {
+      background: $neutral-2;
+      color: $neutral-4;
+      cursor: not-allowed;
+    }
   }
 }
 

--- a/projects/ion/src/lib/input-counter/input-counter.component.scss
+++ b/projects/ion/src/lib/input-counter/input-counter.component.scss
@@ -11,8 +11,11 @@
 
     &:disabled {
       background-color: $neutral-2 !important;
-      pointer-events: none;
       cursor: not-allowed;
+
+      &:hover {
+        background-color: $neutral-2 !important;
+      }
     }
   }
 

--- a/projects/ion/src/lib/input-counter/input-counter.component.scss
+++ b/projects/ion/src/lib/input-counter/input-counter.component.scss
@@ -4,9 +4,16 @@
   display: inline-flex;
   border: 1px solid $neutral-5;
   border-radius: 6px;
+  overflow: hidden;
 
-  ::ng-deep .ion-btn-ghost:disabled {
-    background-color: $neutral-2 !important;
+  ::ng-deep .ion-btn-ghost {
+    border-radius: 0;
+
+    &:disabled {
+      background-color: $neutral-2 !important;
+      pointer-events: none;
+      cursor: not-allowed;
+    }
   }
 
   & input {

--- a/projects/ion/src/lib/input-counter/input-counter.component.spec.ts
+++ b/projects/ion/src/lib/input-counter/input-counter.component.spec.ts
@@ -96,3 +96,37 @@ describe('InputCounter / Size', () => {
     );
   });
 });
+
+describe('InputCounter / Limits', () => {
+  it('should set the maximum value when a bigger number is texted', async () => {
+    const maxValue = 50;
+    await sut({ maxValue });
+    const inputCounter = screen.getByTestId('input-count') as HTMLInputElement;
+    userEvent.type(inputCounter, '1588');
+    fireEvent.blur(inputCounter);
+    expect(inputCounter).toHaveValue(maxValue.toString());
+  });
+
+  it('should set the minimum value when a smaller number is texted', async () => {
+    const minValue = 50;
+    await sut({ minValue });
+    const inputCounter = screen.getByTestId('input-count') as HTMLInputElement;
+    userEvent.clear(inputCounter);
+    userEvent.type(inputCounter, '10');
+    fireEvent.blur(inputCounter);
+    expect(inputCounter).toHaveValue(minValue.toString());
+  });
+});
+
+describe('InputCounter / Disabled', () => {
+  it('should show the disabled state when it is setted ', async () => {
+    await sut({ disabled: true });
+    const inputCounter = screen.getByTestId('input-count') as HTMLInputElement;
+    const subButton = screen.getByTestId('iconSub');
+    const addButton = screen.getByTestId('iconAdd');
+
+    expect(inputCounter).toBeDisabled();
+    expect(subButton.firstChild).toBeDisabled();
+    expect(addButton.firstChild).toBeDisabled();
+  });
+});

--- a/projects/ion/src/lib/input-counter/input-counter.component.spec.ts
+++ b/projects/ion/src/lib/input-counter/input-counter.component.spec.ts
@@ -81,6 +81,7 @@ describe('InputCounter', () => {
     const inputCounter = screen.getByTestId('input-count') as HTMLInputElement;
     const value = '111';
     userEvent.type(inputCounter, value);
+    fireEvent.blur(inputCounter);
     expect(inputCounter.value).toBe(value);
     userEvent.type(inputCounter, 'abc');
     expect(inputCounter.value).toBe(value);
@@ -116,10 +117,19 @@ describe('InputCounter / Limits', () => {
     fireEvent.blur(inputCounter);
     expect(inputCounter).toHaveValue(minValue.toString());
   });
+
+  it('should dont exceed the max value by the increase button when it is clicked', async () => {
+    const maxValue = 100;
+    await sut({ maxValue, count: maxValue });
+    const inputCounter = screen.getByTestId('input-count') as HTMLInputElement;
+    const addButton = screen.getByTestId('iconAdd');
+    userEvent.click(addButton.firstChild as HTMLElement);
+    expect(inputCounter).toHaveValue(maxValue.toString());
+  });
 });
 
 describe('InputCounter / Disabled', () => {
-  it('should show the disabled state when it is setted ', async () => {
+  it('should show the disabled state when it is setted', async () => {
     await sut({ disabled: true });
     const inputCounter = screen.getByTestId('input-count') as HTMLInputElement;
     const subButton = screen.getByTestId('iconSub');

--- a/projects/ion/src/lib/input-counter/input-counter.component.ts
+++ b/projects/ion/src/lib/input-counter/input-counter.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { IonInputCount } from '../core/types';
 
 @Component({
@@ -6,12 +6,13 @@ import { IonInputCount } from '../core/types';
   templateUrl: './input-counter.component.html',
   styleUrls: ['./input-counter.component.scss'],
 })
-export class IonInputCounterComponent {
+export class IonInputCounterComponent implements OnInit {
   @Input() inputSize: IonInputCount['inputSize'] = 'md';
+  @Input() maxValue?: number;
+  @Input() minValue = 0;
+  @Input() disabled = false;
   @Input() count = 0;
   @Output() changedValue = new EventEmitter();
-
-  private minValue = 0;
 
   public emitEvent(): void {
     this.changedValue.emit({ newValue: this.count });
@@ -25,6 +26,7 @@ export class IonInputCounterComponent {
   }
 
   public countIncrement(): void {
+    if (this.maxValue && this.maxValue === this.count) return;
     this.count++;
     this.emitEvent();
   }
@@ -33,7 +35,28 @@ export class IonInputCounterComponent {
     const countNumeric = Number(count);
     if (!isNaN(countNumeric)) {
       this.count = countNumeric;
-      this.emitEvent();
+    } else {
+      this.count = this.minValue;
+    }
+  }
+
+  public onBlurInput(): void {
+    this.count = this.getValidCount();
+    this.emitEvent();
+  }
+
+  private getValidCount(): number {
+    if (this.count < this.minValue) {
+      return this.minValue;
+    } else if (this.maxValue && this.count > this.maxValue) {
+      return this.maxValue;
+    }
+    return this.count;
+  }
+
+  ngOnInit(): void {
+    if (this.minValue) {
+      this.count = this.minValue;
     }
   }
 }

--- a/projects/ion/src/lib/input-counter/input-counter.component.ts
+++ b/projects/ion/src/lib/input-counter/input-counter.component.ts
@@ -14,6 +14,12 @@ export class IonInputCounterComponent implements OnInit {
   @Input() count = 0;
   @Output() changedValue = new EventEmitter();
 
+  ngOnInit(): void {
+    if (this.minValue && !this.count) {
+      this.count = this.minValue;
+    }
+  }
+
   public emitEvent(): void {
     this.changedValue.emit({ newValue: this.count });
   }
@@ -52,11 +58,5 @@ export class IonInputCounterComponent implements OnInit {
       return this.maxValue;
     }
     return this.count;
-  }
-
-  ngOnInit(): void {
-    if (this.minValue) {
-      this.count = this.minValue;
-    }
   }
 }

--- a/projects/ion/src/lib/input-counter/input-counter.component.ts
+++ b/projects/ion/src/lib/input-counter/input-counter.component.ts
@@ -41,8 +41,6 @@ export class IonInputCounterComponent implements OnInit {
     const countNumeric = Number(count);
     if (!isNaN(countNumeric)) {
       this.count = countNumeric;
-    } else {
-      this.count = this.minValue;
     }
   }
 

--- a/projects/ion/src/lib/input-counter/input-counter.component.ts
+++ b/projects/ion/src/lib/input-counter/input-counter.component.ts
@@ -12,6 +12,7 @@ export class IonInputCounterComponent implements OnInit {
   @Input() minValue = 0;
   @Input() disabled = false;
   @Input() count = 0;
+  @Input() maxDigits = 9;
   @Output() changedValue = new EventEmitter();
 
   ngOnInit(): void {

--- a/stories/InputCounter.stories.ts
+++ b/stories/InputCounter.stories.ts
@@ -1,33 +1,50 @@
-import { Meta } from '@storybook/angular/types-6-0';
-import { moduleMetadata, Story } from '@storybook/angular';
+import { Meta, StoryObj } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
 import { IonInputCounterComponent } from '../projects/ion/src/lib/input-counter/input-counter.component';
 import { FormsModule } from '@angular/forms';
 import { IonButtonModule } from '../projects/ion/src/lib/button/button.module';
+import { InputCountSize } from 'ion/public-api';
+import { CommonModule } from '@angular/common';
 
 export default {
   title: 'Ion/Data Entry/Input-Counter',
   component: IonInputCounterComponent,
+  argTypes: {
+    inputSize: {
+      options: ['sm', 'md'] as InputCountSize[],
+      control: { type: 'radio' },
+    },
+  },
   decorators: [
     moduleMetadata({
-      imports: [FormsModule, IonButtonModule],
+      imports: [FormsModule, IonButtonModule, CommonModule],
       declarations: [],
     }),
   ],
-} as Meta;
+} as Meta<IonInputCounterComponent>;
 
-const Template: Story<IonInputCounterComponent> = (
-  args: IonInputCounterComponent
-) => ({
-  component: IonInputCounterComponent,
-  props: args,
-});
+type Story = StoryObj<IonInputCounterComponent>;
 
-export const Small = Template.bind({});
-Small.args = {
-  InputSize: 'sm',
+export const Medium: Story = {
+  args: {},
 };
 
-export const Medium = Template.bind({});
-Medium.args = {
-  InputSize: 'md',
+export const Small: Story = {
+  args: {
+    inputSize: 'sm',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const WithMaxAndMinValues: Story = {
+  name: 'With max and min values',
+  args: {
+    maxValue: 100,
+    minValue: 1,
+  },
 };


### PR DESCRIPTION
## [#1153](https://github.com/Brisanet/ion/issues/1153)
## Description
Adds the min, max and disabled functionalities to the InputCounter component to resolve issue #1153 

## Proposed Changes
- Modified the InputCounter component to accept and handle min, max, and disabled props.
- Added validation logic to restrict input values based on the min and max props.
- Updated the rendering logic to disable the input when the disabled prop is set.

## Compliance
- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
