### PR TITLE
style: not showing badge when dropdown is multiple and button is circular

### DIFF
--- a/projects/ion/src/lib/button/button.component.html
+++ b/projects/ion/src/lib/button/button.component.html
@@ -34,7 +34,7 @@
   <ion-badge
     [value]="buttonBadge?.value"
     [type]="buttonBadge?.type"
-    *ngIf="multiple && !loading"
+    *ngIf="multiple && !loading && !circularButton"
     data-testid="badge-multiple"
   ></ion-badge>
 </button>

--- a/projects/ion/src/lib/button/button.component.spec.ts
+++ b/projects/ion/src/lib/button/button.component.spec.ts
@@ -341,6 +341,17 @@ describe('ButtonComponent with dropdown', () => {
       expect(screen.getByTestId('badge-multiple')).toBeInTheDocument();
       expect(screen.getByTestId('badge-multiple')).toHaveTextContent('0');
     });
+
+    it('should not render an ion-badge when the dropdown is set to multiple but the button is circular', async () => {
+      await sut({
+        label: defaultName,
+        multiple: true,
+        circularButton: true,
+        options: [{ label: 'Option 1' }, { label: 'Option 2' }],
+      });
+
+      expect(screen.queryByTestId('badge-multiple')).not.toBeInTheDocument();
+    });
   });
 
   it('should emit an event when option is selected', async () => {

--- a/stories/Button.stories.mdx
+++ b/stories/Button.stories.mdx
@@ -304,8 +304,15 @@ O Ion, Suporta 4 tamanhos padrões para botões. Basta configurar a propriedade 
         <ion-button
           type="ghost"
           iconType="config"
-          [options]="[{ label: 'option 1' }, {label: 'option 2'}]"
-          [dropdownConfig]="{notShowClearButton: true}"
+          [options]="[
+            { label: 'Ocioso', icon: 'clock-stopwatch' },
+            { label: 'Em deslocamento', icon: 'motorcycle' },
+            { label: 'Trabalhando', icon: 'working' }
+          ]"
+          [dropdownConfig]="{
+            notShowClearButton: true,
+            description: 'Status para acompanhar'
+          }"
           [circularButton]="true"
           [multiple]="true"
         ></ion-button>

--- a/stories/Button.stories.mdx
+++ b/stories/Button.stories.mdx
@@ -296,6 +296,22 @@ O Ion, Suporta 4 tamanhos padrões para botões. Basta configurar a propriedade 
     }}
   </Story>
   <Story
+    name="with dropdown: circular button with multiple choices"
+    decorators={[moduleMetadata({ imports: [CommonModule, IonSharedModule] })]}
+  >
+    {{
+      template: `
+        <ion-button
+          type="ghost"
+          iconType="option"
+          [options]="[{ label: 'option 1' }, {label: 'option 2'}]"
+          circularButton="true"
+          multiple="true"
+        ></ion-button>
+      `,
+    }}
+  </Story>
+  <Story
     name="with dropdown with title"
     decorators={[
       moduleMetadata({

--- a/stories/Button.stories.mdx
+++ b/stories/Button.stories.mdx
@@ -303,10 +303,11 @@ O Ion, Suporta 4 tamanhos padrões para botões. Basta configurar a propriedade 
       template: `
         <ion-button
           type="ghost"
-          iconType="option"
+          iconType="config"
           [options]="[{ label: 'option 1' }, {label: 'option 2'}]"
-          circularButton="true"
-          multiple="true"
+          [dropdownConfig]="{notShowClearButton: true}"
+          [circularButton]="true"
+          [multiple]="true"
         ></ion-button>
       `,
     }}


### PR DESCRIPTION
#1183  

## Description

prevents this behavior:

![image](https://github.com/user-attachments/assets/03faf597-e934-4656-8730-af494d78810f)

## View Storybook

https://62eab350a45bdb0a5818520e-ixytjedbow.chromatic.com/?path=/story/ion-navigation-button--with-dropdown-circular-button-with-multiple-choices

![image](https://github.com/user-attachments/assets/f41b6062-0d0d-42eb-ac20-652315e6f41a)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
