### PR TITLE
feat: add notifications limit option

### DIFF
--- a/projects/ion/src/lib/core/types/notification.ts
+++ b/projects/ion/src/lib/core/types/notification.ts
@@ -16,3 +16,7 @@ export interface NotificationConfigOptions {
   fadeOut?: fadeOutDirection;
   ionOnClose?: EventEmitter<void>;
 }
+
+export interface NotificationServiceConfig {
+  maxStack?: number;
+}

--- a/projects/ion/src/lib/notification/service/notification.container.component.ts
+++ b/projects/ion/src/lib/notification/service/notification.container.component.ts
@@ -7,11 +7,27 @@ import { Component, ComponentRef, Renderer2, ElementRef } from '@angular/core';
   styleUrls: ['notification.container.scss'],
 })
 export class IonNotificationContainerComponent {
+  private notificationRefControl: ComponentRef<IonNotificationComponent>[] = [];
   constructor(private renderer: Renderer2, private element: ElementRef) {}
 
-  addNotification(notification: ComponentRef<IonNotificationComponent>): void {
+  addNotification(
+    notification: ComponentRef<IonNotificationComponent>,
+    maxStack: number
+  ): void {
+    if (this.notificationRefControl.length === maxStack) {
+      this.notificationRefControl[0].instance.ionOnClose.complete();
+      this.removeNotification(
+        this.notificationRefControl[0].location.nativeElement
+      );
+      this.notificationRefControl.shift();
+    }
+
+    this.notificationRefControl.push(notification);
     notification.instance.ionOnClose.subscribe(() => {
       this.removeNotification(notification.location.nativeElement);
+      this.notificationRefControl = this.notificationRefControl.filter(
+        (value) => value !== notification
+      );
     });
 
     this.renderer.appendChild(

--- a/projects/ion/src/lib/notification/service/notification.service.spec.ts
+++ b/projects/ion/src/lib/notification/service/notification.service.spec.ts
@@ -162,3 +162,33 @@ describe('NotificationService -> notification types', () => {
     }
   );
 });
+
+describe('NotificationService -> notification maxStack', () => {
+  let notificationService: IonNotificationService;
+
+  it('should not exceed the maxStack', () => {
+    const removeNotification = screen.getAllByTestId('btn-remove');
+    removeNotification.forEach((element) => fireEvent.click(element));
+
+    TestBed.configureTestingModule({
+      imports: [TestModule],
+    }).compileComponents();
+
+    notificationService = TestBed.get(IonNotificationService);
+
+    notificationService.notificationServiceConfig = { maxStack: 2 };
+    notificationService.success(
+      DEFAULT_NOTIFICATION_OPTIONS.title,
+      DEFAULT_NOTIFICATION_OPTIONS.message
+    );
+    notificationService.error(
+      DEFAULT_NOTIFICATION_OPTIONS.title,
+      DEFAULT_NOTIFICATION_OPTIONS.message
+    );
+    notificationService.error(
+      DEFAULT_NOTIFICATION_OPTIONS.title,
+      DEFAULT_NOTIFICATION_OPTIONS.message
+    );
+    expect(screen.getAllByTestId('ion-notification').length).toBe(2);
+  });
+});

--- a/projects/ion/src/lib/notification/service/notification.service.ts
+++ b/projects/ion/src/lib/notification/service/notification.service.ts
@@ -1,5 +1,8 @@
 import { StatusType } from './../../core/types/status';
-import { NotificationConfigOptions } from './../../core/types/notification';
+import {
+  NotificationConfigOptions,
+  NotificationServiceConfig,
+} from './../../core/types/notification';
 import { IonNotificationComponent } from './../component/notification.component';
 import {
   Injectable,
@@ -25,6 +28,7 @@ enum NOTIFICATION_TYPES {
   providedIn: 'root',
 })
 export class IonNotificationService {
+  public notificationServiceConfig: NotificationServiceConfig = { maxStack: 8 };
   private notificationContainerComponentRef: ComponentRef<IonNotificationContainerComponent>;
   private componentSubscriber!: Subject<SafeAny>;
 
@@ -183,7 +187,8 @@ export class IonNotificationService {
     notification.changeDetectorRef.detectChanges();
 
     this.notificationContainerComponentRef.instance.addNotification(
-      notification
+      notification,
+      this.notificationServiceConfig.maxStack
     );
 
     this.notificationContainerComponentRef.changeDetectorRef.detectChanges();


### PR DESCRIPTION
## Issue Number

fix #1188 

## Description

It was required for the notification service to have a limit on the stack of notifications.

## Proposed Changes

- Added a config property to the service;
- added a control array and a validation to the notification container, so it will close the first notification if the control array is at its max length.

## Compliance

- [X] I have verified that this change complies with our code and contribution policies.
- [X] I have verified that this change does not cause regressions and does not affect other parts of the code.