### PR TITLE
fix: ensure the component fully renders before proceeding to the next step in ionTour

### DIFF
--- a/projects/ion/src/lib/core/types/tour.ts
+++ b/projects/ion/src/lib/core/types/tour.ts
@@ -19,7 +19,7 @@ export interface IonTourStepProps {
   ionOnPrevStep?: EventEmitter<void>;
   ionOnNextStep?: EventEmitter<void>;
   ionOnFinishTour?: EventEmitter<void>;
-  target?: DOMRect;
+  getTarget?: () => DOMRect;
 }
 
 export interface IonStartTourProps {

--- a/projects/ion/src/lib/tour/mocks/resizing-host-demo.component.ts
+++ b/projects/ion/src/lib/tour/mocks/resizing-host-demo.component.ts
@@ -60,6 +60,12 @@ export class TourResizingHostComponent implements OnInit, OnDestroy {
     this.animateButtonSize();
   }
 
+  public ngOnDestroy(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
+
   private animateButtonSize(): void {
     this.interval = setInterval(() => {
       this.top = this.getRandomNumber(0, 700);
@@ -70,11 +76,5 @@ export class TourResizingHostComponent implements OnInit, OnDestroy {
 
   private getRandomNumber(min: number, max: number): number {
     return Math.floor(Math.random() * (max - min + 1)) + min;
-  }
-
-  public ngOnDestroy(): void {
-    if (this.interval) {
-      clearInterval(this.interval);
-    }
   }
 }

--- a/projects/ion/src/lib/tour/mocks/resizing-host-demo.component.ts
+++ b/projects/ion/src/lib/tour/mocks/resizing-host-demo.component.ts
@@ -1,0 +1,80 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+
+import { IonTourService } from '../tour.service';
+
+@Component({
+  selector: 'tour-resizing-host',
+  styles: [
+    `
+      main {
+        height: 800px;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+
+        ion-button {
+          position: absolute;
+        }
+      }
+    `,
+  ],
+  template: `
+    <main>
+      <ion-button
+        data-testid="demo-resizing-button"
+        [style.top.px]="top"
+        [style.left.px]="left"
+        [style.width.px]="buttonWidth"
+        label="Demo"
+        type="secondary"
+        [expand]="true"
+        ionTourStep
+        ionStepId="demo-resizing-step"
+        ionTourId="demo-resizing-tour"
+        ionStepTitle="Title Example"
+        [ionStepBody]="stepBody"
+      ></ion-button>
+    </main>
+
+    <ng-template #stepBody>
+      <p>
+        The host is changing its size and position, but the tour should still
+        work
+      </p>
+    </ng-template>
+  `,
+})
+export class TourResizingHostComponent implements OnInit, OnDestroy {
+  public top = 100;
+  public left = 50;
+  public buttonWidth = 100;
+
+  private interval: ReturnType<typeof setInterval>;
+
+  constructor(private readonly ionTourService: IonTourService) {}
+
+  public ngOnInit(): void {
+    this.ionTourService.start();
+    this.animateButtonSize();
+  }
+
+  private animateButtonSize(): void {
+    this.interval = setInterval(() => {
+      this.top = this.getRandomNumber(0, 700);
+      this.left = this.getRandomNumber(0, 500);
+      this.buttonWidth = this.getRandomNumber(50, 300);
+    }, 700);
+  }
+
+  private getRandomNumber(min: number, max: number): number {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  public ngOnDestroy(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
+}

--- a/projects/ion/src/lib/tour/mocks/tour-basic-demo.component.ts
+++ b/projects/ion/src/lib/tour/mocks/tour-basic-demo.component.ts
@@ -85,8 +85,10 @@ export const STEP3_MOCK: IonTourStepProps = {
           [ionNextStepId]="step2.ionNextStepId"
           [ionStepTitle]="step2.ionStepTitle"
           [ionStepBody]="saveStep"
+          (ionOnNextStep)="markOptionStepAsVisible()"
         ></ion-button>
         <ion-button
+          *ngIf="isOptionStepVisible"
           iconType="option"
           type="secondary"
           ionTourStep
@@ -127,9 +129,15 @@ export class TourBasicDemoComponent {
   public step2 = STEP2_MOCK;
   public step3 = STEP3_MOCK;
 
+  public isOptionStepVisible = false;
+
   constructor(private readonly ionTourService: IonTourService) {}
 
   public startTour(): void {
     this.ionTourService.start();
+  }
+
+  public markOptionStepAsVisible(): void {
+    this.isOptionStepVisible = true;
   }
 }

--- a/projects/ion/src/lib/tour/tour-backdrop/tour-backdrop.component.spec.ts
+++ b/projects/ion/src/lib/tour/tour-backdrop/tour-backdrop.component.spec.ts
@@ -36,9 +36,7 @@ describe('IonTourBackdropComponent', () => {
   it('should render with custom class', async () => {
     const ionStepBackdropCustomClass = 'custom-class';
 
-    await sut({
-      currentStep: { ...STEP_MOCK, ionStepBackdropCustomClass },
-    });
+    await sut({ currentStep: { ...STEP_MOCK, ionStepBackdropCustomClass } });
 
     expect(screen.queryByTestId('ion-tour-backdrop')).toHaveClass(
       ionStepBackdropCustomClass

--- a/projects/ion/src/lib/tour/tour-backdrop/tour-backdrop.component.spec.ts
+++ b/projects/ion/src/lib/tour/tour-backdrop/tour-backdrop.component.spec.ts
@@ -57,6 +57,14 @@ describe('IonTourBackdropComponent', () => {
       expect(screen.queryByTestId('ion-tour-backdrop')).not.toBeInTheDocument();
     });
 
+    it('should backdrop with empty clip-path when the step is not active', async () => {
+      const { fixture } = await sut();
+      fixture.componentInstance.updateStep(null);
+      expect(screen.queryByTestId('ion-tour-backdrop')).toHaveStyle({
+        clipPath: '',
+      });
+    });
+
     it('should stop rendering when performFinalTransition is called', async () => {
       jest.useFakeTimers();
       const { fixture } = await sut({ inTransition: true });

--- a/projects/ion/src/lib/tour/tour-backdrop/tour-backdrop.component.spec.ts
+++ b/projects/ion/src/lib/tour/tour-backdrop/tour-backdrop.component.spec.ts
@@ -15,7 +15,7 @@ const sut = async (
 };
 
 const STEP_MOCK = {
-  target: {
+  getTarget: () => ({
     x: 300,
     y: 300,
     width: 100,
@@ -24,7 +24,7 @@ const STEP_MOCK = {
     right: 400,
     left: 300,
     top: 300,
-  } as DOMRect,
+  }),
 } as IonTourStepProps;
 
 describe('IonTourBackdropComponent', () => {

--- a/projects/ion/src/lib/tour/tour-backdrop/tour-backdrop.component.ts
+++ b/projects/ion/src/lib/tour/tour-backdrop/tour-backdrop.component.ts
@@ -19,8 +19,8 @@ export class IonTourBackdropComponent implements OnInit {
       return '';
     }
 
-    const { target, ionStepBackdropPadding: padding } = this.currentStep;
-    const { top, left, bottom, right } = target;
+    const { getTarget, ionStepBackdropPadding: padding } = this.currentStep;
+    const { top, left, bottom, right } = getTarget();
 
     return this.sanitizer.bypassSecurityTrustStyle(`polygon(
       0 0,

--- a/projects/ion/src/lib/tour/tour-step.directive.spec.ts
+++ b/projects/ion/src/lib/tour/tour-step.directive.spec.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, ElementRef, ViewContainerRef } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import {
   fireEvent,
   render,
@@ -13,12 +13,12 @@ import { EMPTY, of } from 'rxjs';
 import { IonButtonModule } from '../button/button.module';
 import { IonTourStepProps } from '../core/types';
 import { IonPopoverModule } from '../popover/popover.module';
+import { IonPositionService } from '../position/position.service';
 import { TourResizingHostComponent } from './mocks/resizing-host-demo.component';
 import { TourStepDemoComponent } from './mocks/tour-step-props.component';
+import { IonTourStepDirective } from './tour-step.directive';
 import { IonTourModule } from './tour.module';
 import { IonTourService } from './tour.service';
-import { IonTourStepDirective } from './tour-step.directive';
-import { IonPositionService } from '../position/position.service';
 
 const DEFAULT_PROPS: Partial<TourStepDemoComponent> = {
   ionTourId: 'demo-tour',

--- a/projects/ion/src/lib/tour/tour-step.directive.spec.ts
+++ b/projects/ion/src/lib/tour/tour-step.directive.spec.ts
@@ -1,19 +1,24 @@
+import { ChangeDetectorRef, ElementRef, ViewContainerRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   fireEvent,
   render,
   RenderResult,
   screen,
 } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
 import { cloneDeep } from 'lodash';
 import { EMPTY, of } from 'rxjs';
 
 import { IonButtonModule } from '../button/button.module';
 import { IonTourStepProps } from '../core/types';
+import { IonPopoverModule } from '../popover/popover.module';
+import { TourResizingHostComponent } from './mocks/resizing-host-demo.component';
 import { TourStepDemoComponent } from './mocks/tour-step-props.component';
 import { IonTourModule } from './tour.module';
 import { IonTourService } from './tour.service';
-import { IonPopoverModule } from '../popover/popover.module';
-import userEvent from '@testing-library/user-event';
+import { IonTourStepDirective } from './tour-step.directive';
+import { IonPositionService } from '../position/position.service';
 
 const DEFAULT_PROPS: Partial<TourStepDemoComponent> = {
   ionTourId: 'demo-tour',
@@ -23,7 +28,7 @@ const DEFAULT_PROPS: Partial<TourStepDemoComponent> = {
   ionNextStepBtn: { label: 'Test Next' },
 };
 
-const tourServiceMock: Partial<IonTourService> = {
+const tourServiceMock = {
   saveStep: jest.fn(),
   removeStep: jest.fn(),
   start: jest.fn(),
@@ -32,6 +37,26 @@ const tourServiceMock: Partial<IonTourService> = {
   nextStep: jest.fn(),
   activeTour$: EMPTY,
   currentStep$: EMPTY,
+};
+
+const generateRandomDOMRect = (): DOMRect => {
+  const data = {
+    x: Math.random() * 100,
+    y: Math.random() * 100,
+    width: Math.random() * 200 + 50,
+    height: Math.random() * 200 + 50,
+    bottom: Math.random() * 100 + 200,
+    right: Math.random() * 100 + 200,
+    left: Math.random() * 50,
+    top: Math.random() * 50,
+  };
+  return { ...data, toJSON: () => data } as DOMRect;
+};
+
+const elementRefMock = {
+  nativeElement: {
+    getBoundingClientRect: jest.fn().mockImplementation(generateRandomDOMRect),
+  },
 };
 
 function setActiveTour(tourId: string): void {
@@ -49,15 +74,41 @@ const sut = async (
 ): Promise<RenderResult<TourStepDemoComponent>> => {
   const result = await render(TourStepDemoComponent, {
     imports: [IonButtonModule, IonTourModule, IonPopoverModule],
-    providers: [{ provide: IonTourService, useValue: tourServiceMock }],
+    providers: [
+      { provide: ElementRef, useValue: elementRefMock },
+      { provide: IonTourService, useValue: tourServiceMock },
+    ],
     componentProperties: {
       ...DEFAULT_PROPS,
       ...props,
     },
   });
-  jest.runAllTimers();
+  jest.runOnlyPendingTimers();
   result.fixture.detectChanges();
   return result;
+};
+
+const sutResizingHostDemo = (): void => {
+  TestBed.configureTestingModule({
+    imports: [IonButtonModule, IonTourModule, IonPopoverModule],
+    declarations: [TourResizingHostComponent],
+    providers: [
+      IonTourService,
+      IonTourStepDirective,
+      IonPositionService,
+      ViewContainerRef,
+      ChangeDetectorRef,
+      { provide: ElementRef, useValue: elementRefMock },
+    ],
+  });
+
+  TestBed.get(IonTourStepDirective)['hostPositionChanged'] = jest
+    .fn()
+    .mockReturnValue(true);
+
+  TestBed.createComponent(TourResizingHostComponent).detectChanges();
+
+  jest.runOnlyPendingTimers();
 };
 
 describe('IonTourStepDirective', () => {
@@ -101,6 +152,18 @@ describe('IonTourStepDirective', () => {
     fixture.detectChanges();
 
     expect(screen.queryByText(newlabel)).toBeInTheDocument();
+  });
+
+  it('should reposition popover when host position changes', async () => {
+    sutResizingHostDemo();
+
+    const directive = TestBed.get(IonTourStepDirective);
+    const spy = jest.spyOn(directive, 'repositionPopover');
+    directive.observeHostPosition();
+
+    jest.runOnlyPendingTimers();
+
+    expect(spy).toHaveBeenCalled();
   });
 
   describe('popover actions', () => {

--- a/projects/ion/src/lib/tour/tour-step.directive.ts
+++ b/projects/ion/src/lib/tour/tour-step.directive.ts
@@ -28,7 +28,6 @@ import { IonPositionService } from '../position/position.service';
 import { SafeAny } from '../utils/safe-any';
 import { generatePositionCallback } from './tour-position.calculator';
 import { IonTourService } from './tour.service';
-import { isEqual } from 'lodash';
 
 @Directive({ selector: '[ionTourStep]' })
 export class IonTourStepDirective implements OnInit, OnChanges, OnDestroy {

--- a/projects/ion/src/lib/tour/tour-step.directive.ts
+++ b/projects/ion/src/lib/tour/tour-step.directive.ts
@@ -225,9 +225,14 @@ export class IonTourStepDirective implements OnInit, OnChanges, OnDestroy {
   }
 
   private hostPositionChanged(): boolean {
-    return !isEqual(
-      this.hostPosition,
-      this.elementRef.nativeElement.getBoundingClientRect()
+    const newPosition = this.elementRef.nativeElement.getBoundingClientRect();
+    return (
+      this.hostPosition &&
+      newPosition &&
+      this.hostPosition.x === newPosition.x &&
+      this.hostPosition.y === newPosition.y &&
+      this.hostPosition.width === newPosition.width &&
+      this.hostPosition.height === newPosition.height
     );
   }
 

--- a/projects/ion/src/lib/tour/tour-step.directive.ts
+++ b/projects/ion/src/lib/tour/tour-step.directive.ts
@@ -91,6 +91,8 @@ export class IonTourStepDirective implements OnInit, OnChanges, OnDestroy {
             this.isStepSelected = isSameStep;
             this.checkPopoverVisibility();
           }
+        } else {
+          this.isStepSelected = false;
         }
       });
   }

--- a/projects/ion/src/lib/tour/tour-step.directive.ts
+++ b/projects/ion/src/lib/tour/tour-step.directive.ts
@@ -226,7 +226,7 @@ export class IonTourStepDirective implements OnInit, OnChanges, OnDestroy {
 
   private hostPositionChanged(): boolean {
     const newPosition = this.elementRef.nativeElement.getBoundingClientRect();
-    return (
+    return !(
       this.hostPosition &&
       newPosition &&
       this.hostPosition.x === newPosition.x &&

--- a/projects/ion/src/lib/tour/tour-step.directive.ts
+++ b/projects/ion/src/lib/tour/tour-step.directive.ts
@@ -72,16 +72,25 @@ export class IonTourStepDirective implements OnInit, OnChanges, OnDestroy {
 
     this.tourService.activeTour$
       .pipe(takeUntil(this.destroy$))
-      .subscribe((isActive) => {
-        this.isTourActive = isActive === this.ionTourId;
+      .subscribe((activeTourId) => {
+        this.isTourActive = activeTourId === this.ionTourId;
         this.checkPopoverVisibility();
       });
 
     this.tourService.currentStep$
       .pipe(takeUntil(this.destroy$))
       .subscribe((step) => {
-        this.isStepSelected = step && step.ionStepId === this.ionStepId;
-        this.checkPopoverVisibility();
+        if (!this.isStepSelected && step && step.ionStepId === this.ionStepId) {
+          this.isStepSelected = true;
+          this.checkPopoverVisibility();
+        } else if (
+          this.isStepSelected &&
+          step &&
+          step.ionStepId !== this.ionStepId
+        ) {
+          this.isStepSelected = false;
+          this.checkPopoverVisibility();
+        }
       });
   }
 
@@ -178,6 +187,7 @@ export class IonTourStepDirective implements OnInit, OnChanges, OnDestroy {
     }
 
     this.cdr.detectChanges();
+    this.repositionPopover();
   }
 
   private listenToPopoverEvents(): void {
@@ -220,7 +230,7 @@ export class IonTourStepDirective implements OnInit, OnChanges, OnDestroy {
       ionOnPrevStep: this.ionOnPrevStep,
       ionOnNextStep: this.ionOnNextStep,
       ionOnFinishTour: this.ionOnFinishTour,
-      target: this.elementRef.nativeElement.getBoundingClientRect(),
+      getTarget: () => this.elementRef.nativeElement.getBoundingClientRect(),
     };
   }
 }

--- a/projects/ion/src/lib/tour/tour.service.spec.ts
+++ b/projects/ion/src/lib/tour/tour.service.spec.ts
@@ -55,7 +55,7 @@ const stepsMock: IonTourStepProps[] = [
   {
     ionTourId: 'tour1',
     ionStepId: 'step1',
-    target: TARGET_MOCK,
+    getTarget: () => TARGET_MOCK,
     ionStepTitle: 'Step 1',
     ionNextStepId: 'step2',
     ionOnPrevStep: new EventEmitter(),
@@ -65,7 +65,7 @@ const stepsMock: IonTourStepProps[] = [
   {
     ionTourId: 'tour1',
     ionStepId: 'step2',
-    target: TARGET_MOCK,
+    getTarget: () => TARGET_MOCK,
     ionStepTitle: 'Step 2',
     ionPrevStepId: 'step1',
     ionOnPrevStep: new EventEmitter(),
@@ -237,6 +237,7 @@ describe('IonTourService', () => {
 
       const spy = jest.spyOn(step1.ionOnNextStep, 'emit');
       service.nextStep();
+      jest.runAllTimers();
 
       expect(service.currentStep.value).toEqual(step2);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -251,6 +252,7 @@ describe('IonTourService', () => {
       jest.runAllTimers();
 
       service.nextStep();
+      jest.runAllTimers();
 
       expect(service.currentStep.value).toEqual(step2);
 
@@ -271,9 +273,10 @@ describe('IonTourService', () => {
       const spyNext = jest.spyOn(step.ionOnNextStep, 'emit');
       const spyFinish = jest.spyOn(step.ionOnFinishTour, 'emit');
       service.nextStep();
+      jest.runAllTimers();
 
-      expect(service.currentStep.value).toBeNull();
-      expect(service.activeTour.value).toBeNull();
+      expect(service.currentStep.value).toBeUndefined();
+      expect(service.activeTour.value).toBeUndefined();
       expect(spyNext).toHaveBeenCalledTimes(1);
       expect(spyFinish).toHaveBeenCalledTimes(1);
     });

--- a/projects/ion/src/lib/tour/tour.service.spec.ts
+++ b/projects/ion/src/lib/tour/tour.service.spec.ts
@@ -125,7 +125,7 @@ describe('IonTourService', () => {
 
       const updatedStep = {
         ...step1,
-        target: { toJSON: () => ({ ...TARGET_MOCK, x: 400 }) },
+        getTarget: () => ({ toJSON: () => ({ ...TARGET_MOCK, x: 400 }) }),
       } as IonTourStepProps;
 
       service.saveStep(step1);
@@ -134,6 +134,7 @@ describe('IonTourService', () => {
 
       expect(service.currentStep.value).toEqual(step1);
       service.saveStep(updatedStep);
+      jest.runAllTimers();
       expect(service.currentStep.value).toEqual(updatedStep);
     });
   });
@@ -258,13 +259,14 @@ describe('IonTourService', () => {
 
       const spy = jest.spyOn(step2.ionOnPrevStep, 'emit');
       service.prevStep();
+      jest.runAllTimers();
 
       expect(service.currentStep.value).toEqual(step1);
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should finish the tour if there is no next step and nextStep is called', () => {
-      const [step] = stepsMock;
+      const step = { ...stepsMock[0], ionNextStepId: undefined };
 
       service.saveStep(step);
       service.start({ tourId: step.ionTourId });
@@ -275,8 +277,8 @@ describe('IonTourService', () => {
       service.nextStep();
       jest.runAllTimers();
 
-      expect(service.currentStep.value).toBeUndefined();
-      expect(service.activeTour.value).toBeUndefined();
+      expect(service.currentStep.value).toBeNull();
+      expect(service.activeTour.value).toBeNull();
       expect(spyNext).toHaveBeenCalledTimes(1);
       expect(spyFinish).toHaveBeenCalledTimes(1);
     });
@@ -291,6 +293,7 @@ describe('IonTourService', () => {
       const spyPrev = jest.spyOn(step.ionOnPrevStep, 'emit');
       const spyFinish = jest.spyOn(step.ionOnFinishTour, 'emit');
       service.prevStep();
+      jest.runAllTimers();
 
       expect(service.currentStep.value).toBeNull();
       expect(service.activeTour.value).toBeNull();

--- a/projects/ion/src/lib/tour/tour.service.spec.ts
+++ b/projects/ion/src/lib/tour/tour.service.spec.ts
@@ -125,7 +125,9 @@ describe('IonTourService', () => {
 
       const updatedStep = {
         ...step1,
-        getTarget: () => ({ toJSON: () => ({ ...TARGET_MOCK, x: 400 }) }),
+        getTarget: () => ({
+          toJSON: (): DOMRect => ({ ...TARGET_MOCK, x: 400 }),
+        }),
       } as IonTourStepProps;
 
       service.saveStep(step1);

--- a/projects/ion/src/lib/tour/tour.service.spec.ts
+++ b/projects/ion/src/lib/tour/tour.service.spec.ts
@@ -26,7 +26,7 @@ const backdropComponentMock = {
   hostView: {},
   location: { nativeElement: document.createElement('div') },
   changeDetectorRef: { detectChanges: jest.fn() },
-  instance: { performFinalTransition },
+  instance: { performFinalTransition, updateStep: jest.fn() },
   destroy: jest.fn(),
 };
 

--- a/projects/ion/src/lib/tour/tour.service.ts
+++ b/projects/ion/src/lib/tour/tour.service.ts
@@ -55,12 +55,7 @@ export class IonTourService {
     }
 
     const current = this.currentStep.value;
-
-    if (
-      current &&
-      current.ionStepId === step.ionStepId &&
-      !isEqual(step.getTarget(), current.getTarget())
-    ) {
+    if (current && current.ionStepId === step.ionStepId) {
       this.navigateToStep(step);
     }
 
@@ -154,6 +149,7 @@ export class IonTourService {
 
   private navigateToStep(step: IonTourStepProps): void {
     this.currentStep.next(step);
+    console.log('step', step);
   }
 
   private createBackdrop(): void {
@@ -180,7 +176,7 @@ export class IonTourService {
       .pipe(takeUntil(this.destroyBackdrop$))
       .subscribe((step) => {
         if (this.backdropRef) {
-          this.backdropRef.instance.currentStep = step;
+          this.backdropRef.instance.updateStep(step);
         }
       });
 

--- a/projects/ion/src/lib/tour/tour.service.ts
+++ b/projects/ion/src/lib/tour/tour.service.ts
@@ -59,7 +59,7 @@ export class IonTourService {
     if (
       current &&
       current.ionStepId === step.ionStepId &&
-      !isEqual(step.getTarget().toJSON(), current.getTarget().toJSON())
+      !isEqual(step.getTarget(), current.getTarget())
     ) {
       this.navigateToStep(step);
     }
@@ -105,12 +105,12 @@ export class IonTourService {
 
   public prevStep(): void {
     const currentStep = this.currentStep.getValue();
+    currentStep.ionOnPrevStep.emit();
+
     if (!currentStep.ionPrevStepId) {
       this.finish();
       return;
     }
-
-    currentStep.ionOnPrevStep.emit();
 
     setTimeout(() => {
       const prevStep = this._tours[this.activeTourId].get(
@@ -125,12 +125,12 @@ export class IonTourService {
 
   public nextStep(): void {
     const currentStep = this.currentStep.getValue();
+    currentStep.ionOnNextStep.emit();
+
     if (!currentStep.ionNextStepId) {
       this.finish();
       return;
     }
-
-    currentStep.ionOnNextStep.emit();
 
     setTimeout(() => {
       const nextStep = this._tours[this.activeTourId].get(

--- a/projects/ion/src/lib/tour/tour.service.ts
+++ b/projects/ion/src/lib/tour/tour.service.ts
@@ -59,7 +59,7 @@ export class IonTourService {
     if (
       current &&
       current.ionStepId === step.ionStepId &&
-      !isEqual(step.target.toJSON(), current.target.toJSON())
+      !isEqual(step.getTarget().toJSON(), current.getTarget().toJSON())
     ) {
       this.navigateToStep(step);
     }
@@ -105,27 +105,32 @@ export class IonTourService {
 
   public prevStep(): void {
     const currentStep = this.currentStep.getValue();
+    if (!currentStep.ionPrevStepId) {
+      this.finish();
+      return;
+    }
+
     currentStep.ionOnPrevStep.emit();
 
-    const prevStep = this._tours[this.activeTourId].get(
-      currentStep.ionPrevStepId
-    );
+    setTimeout(() => {
+      const prevStep = this._tours[this.activeTourId].get(
+        currentStep.ionPrevStepId
+      );
 
-    if (prevStep) {
-      this.navigateToStep(prevStep);
-    } else {
-      this.finish();
-    }
+      if (prevStep) {
+        this.navigateToStep(prevStep);
+      }
+    });
   }
 
   public nextStep(): void {
     const currentStep = this.currentStep.getValue();
-    currentStep.ionOnNextStep.emit();
-
     if (!currentStep.ionNextStepId) {
       this.finish();
       return;
     }
+
+    currentStep.ionOnNextStep.emit();
 
     setTimeout(() => {
       const nextStep = this._tours[this.activeTourId].get(
@@ -162,10 +167,10 @@ export class IonTourService {
 
     this.appRef.attachView(this.backdropRef.hostView);
 
-    const popoverElement = this.backdropRef.location
+    const backdropElement = this.backdropRef.location
       .nativeElement as HTMLElement;
 
-    this.document.body.appendChild(popoverElement);
+    this.document.body.appendChild(backdropElement);
     this.backdropRef.changeDetectorRef.detectChanges();
     this.updateBackdropProps();
   }

--- a/projects/ion/src/lib/tour/tour.service.ts
+++ b/projects/ion/src/lib/tour/tour.service.ts
@@ -122,15 +122,18 @@ export class IonTourService {
     const currentStep = this.currentStep.getValue();
     currentStep.ionOnNextStep.emit();
 
-    const nextStep = this._tours[this.activeTourId].get(
-      currentStep.ionNextStepId
-    );
-
-    if (nextStep) {
-      this.navigateToStep(nextStep);
-    } else {
+    if (!currentStep.ionNextStepId) {
       this.finish();
+      return;
     }
+
+    setTimeout(() => {
+      const nextStep = this._tours[this.activeTourId].get(
+        currentStep.ionNextStepId
+      );
+
+      this.navigateToStep(nextStep);
+    });
   }
 
   private getFirstStep(

--- a/projects/ion/src/lib/tour/tour.service.ts
+++ b/projects/ion/src/lib/tour/tour.service.ts
@@ -149,7 +149,6 @@ export class IonTourService {
 
   private navigateToStep(step: IonTourStepProps): void {
     this.currentStep.next(step);
-    console.log('step', step);
   }
 
   private createBackdrop(): void {

--- a/stories/TourDocs.stories.mdx
+++ b/stories/TourDocs.stories.mdx
@@ -40,10 +40,9 @@ Passos para usar o tour em uma tela:
 - `ionStepMarginToContent` é o espaçamento entre o balão de fala e o inicio da borda do backdrop;
 - `ionStepBackdropPadding` é o espaçamento que fica entre o elemento destacado e o inicio da borda escurecida do backdrop;
 - `ionStepCustomClass` é uma classe customizada que pode ser aplicada ao balão de fala da etapa;
-- `ionStepBackdropCustomClas` é uma classe customizada que pode ser aplicada ao backdrop da etapa;
+- `ionStepBackdropCustomClass` é uma classe customizada que pode ser aplicada ao backdrop da etapa;
 - `ionOnPrevStep` é um evento que será disparado ao clicar no botão de voltar para a etapa anterior;
 - `ionOnNextStep` é um evento que será disparado ao clicar no botão de avançar para a próxima etapa;
-- `ionOnCloseStep` é um evento que será disparado ao clicar no botão de fechar o tour.
 
 2. No arquivo .ts do seu componente, use o serviço `IonTourService` para iniciar o tour:
 

--- a/stories/TourResizing.stories.ts
+++ b/stories/TourResizing.stories.ts
@@ -1,0 +1,33 @@
+import { CommonModule } from '@angular/common';
+import { Meta, Story } from '@storybook/angular';
+
+import { IonTourModule } from '../projects/ion/src/lib/tour';
+import { IonSharedModule } from '../projects/ion/src/public-api';
+import { TourResizingHostComponent } from '../projects/ion/src/lib/tour/mocks/resizing-host-demo.component';
+
+const Template: Story<TourResizingHostComponent> = (
+  args: TourResizingHostComponent
+) => ({
+  component: TourResizingHostComponent,
+  props: args,
+  moduleMetadata: {
+    declarations: [TourResizingHostComponent],
+    imports: [CommonModule, IonSharedModule, IonTourModule],
+    entryComponents: [TourResizingHostComponent],
+  },
+});
+
+export const HostResizing = Template.bind({});
+HostResizing.args = {
+  ionStepTitle: 'Title Example',
+  ionStepBody: 'You can change the props of this step in Storybook controls',
+  ionPrevStepBtn: { label: 'Close' },
+  ionNextStepBtn: { label: 'Finish' },
+  ionStepMarginToContent: 5,
+  ionStepBackdropPadding: 5,
+};
+
+export default {
+  title: 'Ion/Data Display/Tour',
+  component: TourResizingHostComponent,
+} as Meta<TourResizingHostComponent>;


### PR DESCRIPTION
#1221

# Ensure the component fully renders before proceeding to the next step in ionTour

[Storybook](https://62eab350a45bdb0a5818520e-twpcivyupl.chromatic.com/?path=/story/ion-data-display-tour--basic-tour)
