### PR TITLE
feat: adding dark theme to the tag

### DIFF
--- a/projects/ion/src/lib/tag/_tag.theme.scss
+++ b/projects/ion/src/lib/tag/_tag.theme.scss
@@ -1,0 +1,65 @@
+@import '../../styles/themes/theme.scss';
+
+$default: (
+  success: (
+    background-color: var(--ion-positive-1),
+    border-color: var(--ion-positive-7),
+    color: var(--ion-positive-7),
+  ),
+  warning: (
+    background-color: var(--ion-warning-1),
+    border-color: var(--ion-warning-7),
+    color: var(--ion-warning-7),
+  ),
+  info: (
+    background-color: var(--ion-info-1),
+    border-color: var(--ion-info-7),
+    color: var(--ion-info-7),
+  ),
+  negative: (
+    background-color: var(--ion-negative-1),
+    border-color: var(--ion-negative-1),
+    color: var(--ion-negative-7),
+  ),
+  neutral: (
+    background-color: var(--ion-neutral-2),
+    border-color: var(--ion-neutral-2),
+    color: var(--ion-neutral-7),
+  ),
+);
+
+$dark: (
+  success: (
+    background-color: var(--ion-neutral-6),
+    border-color: var(--ion-positive-4),
+    color: var(--ion-positive-4),
+  ),
+  warning: (
+    background-color: var(--ion-neutral-6),
+    border-color: var(--ion-warning-4),
+    color: var(--ion-warning-4),
+  ),
+  info: (
+    background-color: var(--ion-neutral-6),
+    border-color: var(--ion-info-5),
+    color: var(--ion-info-5),
+  ),
+  negative: (
+    background-color: var(--ion-neutral-6),
+    border-color: var(--ion-negative-4),
+    color: var(--ion-negative-4),
+  ),
+  neutral: (
+    background-color: var(--ion-neutral-6),
+    border-color: var(--ion-neutral-1),
+    color: var(--ion-neutral-1),
+  ),
+);
+
+@include register-component(
+  tag,
+  (
+    default: $default,
+    dark: $dark,
+  )
+);

--- a/projects/ion/src/lib/tag/tag.component.scss
+++ b/projects/ion/src/lib/tag/tag.component.scss
@@ -1,13 +1,16 @@
-@import '../../styles/index.scss';
+@use 'tag.theme';
 
-@mixin tag-context($backgroud, $color) {
-  background-color: $backgroud;
-  border-color: $color;
-  color: $color;
+@import '../../styles/index.scss';
+@import '../../styles/themes/theme.scss';
+
+@mixin tag-context($prefix) {
+  background-color: ion-theme(#{$prefix}-background-color);
+  border-color: ion-theme(#{$prefix}-border-color) !important;
+  color: ion-theme(#{$prefix}-color);
 
   .tag-icon {
     ::ng-deep svg {
-      fill: $color;
+      fill: ion-theme(#{$prefix}-color);
     }
   }
 }
@@ -41,22 +44,8 @@
   border: 1px solid;
 }
 
-.success {
-  @include tag-context($positive-1, $positive-7);
-}
-
-.warning {
-  @include tag-context($warning-1, $warning-7);
-}
-
-.info {
-  @include tag-context($info-1, $info-7);
-}
-
-.negative {
-  @include tag-context($negative-1, $negative-7);
-}
-
-.neutral {
-  @include tag-context($neutral-2, $neutral-7);
+@each $variant in success, warning, info, negative, neutral {
+  .#{$variant} {
+     @include tag-context(tag-#{$variant});
+  }
 }


### PR DESCRIPTION
feat #1248

## Description

adding dark theme in ion-tag

## Proposed Changes

- added _tag.theme.scss file
- modified tag.component.scss file

## Screenshots

<img width="737" height="527" alt="image" src="https://github.com/user-attachments/assets/fabe7ac6-6d8d-466f-9967-12066a0f51d2" />

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.