### PR TITLE
feat: add background input to the tag #1249

### DIFF
--- a/projects/ion/src/lib/core/types/tag.ts
+++ b/projects/ion/src/lib/core/types/tag.ts
@@ -6,4 +6,5 @@ export interface IonTagProps {
   color?: string;
   label: string;
   icon?: string;
+  backgroundColor?: string;
 }

--- a/projects/ion/src/lib/tag/tag.component.html
+++ b/projects/ion/src/lib/tag/tag.component.html
@@ -2,7 +2,7 @@
   *ngIf="label"
   data-testid="ion-tag"
   [style.color]="tagStyle()"
-  [style.background]="tagStyle() + '1A'"
+  [style.background]="tagBackgroundColor()"
   [class]="setTagType()"
 >
   <ion-icon

--- a/projects/ion/src/lib/tag/tag.component.spec.ts
+++ b/projects/ion/src/lib/tag/tag.component.spec.ts
@@ -130,4 +130,45 @@ describe('IonTagComponent', () => {
     await sut({ ...defaultValue, color: invalid_color });
     expect(screen.getByTestId(IDs.tag)).toHaveStyle(`color: ${defaultColor};`);
   });
+
+  it.each(customColors)(
+    'should render with background color derived from custom color: %s',
+    async (color) => {
+      await sut({ ...defaultValue, color: color });
+      expect(await screen.findByTestId(IDs.tag)).toHaveStyle(
+        `background: ${color}1A;`
+      );
+    }
+  );
+
+  it.each(customColors)(
+    'should render with a specific custom background color: %s',
+    async (backgroundColor) => {
+      await sut({ ...defaultValue, backgroundColor: backgroundColor });
+      expect(await screen.findByTestId(IDs.tag)).toHaveStyle(
+        `background: ${backgroundColor};`
+      );
+    }
+  );
+
+  it('should use default background color when an invalid background color is provided', async () => {
+    const invalidColor = 'invalid-color';
+    await sut({ ...defaultValue, backgroundColor: invalidColor });
+    expect(screen.getByTestId(IDs.tag)).toHaveStyle(
+      `background: ${defaultColor}1A;`
+    );
+  });
+
+  it('should not apply a custom background color when a status is defined', async () => {
+    const backgroundColor = '#19243B';
+    await sut({
+      ...defaultValue,
+      status: 'success',
+      backgroundColor: backgroundColor,
+    });
+    expect(screen.getByTestId(IDs.tag)).not.toHaveStyle(
+      `background: ${backgroundColor};`
+    );
+    expect(screen.getByTestId(IDs.tag)).toHaveStyle('background:;');
+  });
 });

--- a/projects/ion/src/lib/tag/tag.component.ts
+++ b/projects/ion/src/lib/tag/tag.component.ts
@@ -15,6 +15,7 @@ export class IonTagComponent implements OnInit, OnChanges {
   @Input() label!: string;
   @Input() status?: TagStatus;
   @Input() color?: string = defaultColor;
+  @Input() backgroundColor?: string;
   @Input() icon?: IconType;
 
   ngOnInit(): void {
@@ -37,6 +38,18 @@ export class IonTagComponent implements OnInit, OnChanges {
 
   getTagColor(): string {
     return validateHexColor(this.color) ? this.color : defaultColor;
+  }
+
+  tagBackgroundColor(): string {
+    if (this.status) {
+      return '';
+    }
+
+    if (this.backgroundColor && validateHexColor(this.backgroundColor)) {
+      return this.backgroundColor;
+    }
+
+    return this.tagStyle() + '1A';
   }
 
   hasLabel(): boolean {

--- a/stories/Tag.stories.mdx
+++ b/stories/Tag.stories.mdx
@@ -216,6 +216,32 @@ Por meio do parâmetro `color` pode ser passado cores customizadas para a tag
   </Story>
 </Canvas>
 
+## Fundo customizado (background)
+
+Por meio do parâmetro `background` pode ser passada uma cor de fundo customizada para a tag.
+
+- Esse atributo aceita cores em hexadecimal.
+- Caso seja passado juntamente com o `status`, a tag irá priorizar o status e desconsiderará a cor de fundo passada.
+- Se a propriedade `color` for usada em conjunto, ela definirá a cor do texto e da borda, enquanto `background` definirá a cor de fundo.
+
+<Canvas>
+  <Story
+    name="type: background"
+    args={{
+      label: 'Fundo customizado',
+      backgroundColor: '#E6F3FF',
+      color: '#0065D9',
+    }}
+    decorators={[
+      moduleMetadata({
+        imports: [CommonModule, IonSharedModule],
+      }),
+    ]}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
 ## Icone(icon)
 
 Por meio do parâmetro `icon` pode ser passado diferentes tipos de icones(dentro do IonIconComponent)


### PR DESCRIPTION
#1249 

feat #1249 

## Description

Adding background input to the tag

## Screenshots

<img width="1021" height="909" alt="image" src="https://github.com/user-attachments/assets/f1339ea5-7eaf-4b26-82ba-1ff7d3bd9a1f" />

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
