### PR TITLE
ci: update Code Coverage Action for Qlty

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Run Tests
         run: yarn test:coverage
 
-      - uses: paambaati/codeclimate-action@v3.0.0
+      - uses: qltysh/qlty-action/coverage@v1
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
         with:
-          coverageCommand: yarn test:coverage
+          files: ./coverage/lcov.info
 
       - name: Run Prettier
         run: yarn prettier

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
         with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: ./coverage/lcov.info
 
       - name: Run Prettier

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         node-version: [12.22.1]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -25,4 +25,5 @@ jobs:
         env:
           QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
         with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: ./coverage/lcov.info

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Install packages
         run: yarn install --frozen-lockfile
 
-      - uses: paambaati/codeclimate-action@v3.0.0
+      - uses: qltysh/qlty-action/coverage@v1
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          QLTY_COVERAGE_TOKEN: ${{ secrets.QLTY_COVERAGE_TOKEN }}
         with:
-          coverageCommand: yarn test:coverage
+          files: ./coverage/lcov.info

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         node-version: [12.22.1]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
**Description**
This pull request migrates our CI workflow for code coverage reporting from the deprecated Code Climate platform to the new, official Qlty Cloud service.

**Context**
The original Code Climate Quality platform is being shut down and replaced by a completely rebuilt service called Qlty. As a result, the `paambaati/codeclimate-action` we were using is now obsolete and points to a service that will no longer be maintained. This migration is necessary to ensure our code coverage reporting continues to function correctly.

**Summary of Changes**
- Replaced the community-maintained `paambaati/codeclimate-action` with the official `qltysh/qlty-action/coverage@v1` action.
- Updated the authentication method from the `CC_TEST_REPORTER_ID` environment variable to the new token input, which uses the `QLTY_COVERAGE_TOKEN` secret.